### PR TITLE
[#1] - Apple Watch: HealthKit에서 workout세션 구현 + 실시간 데이터 갖고오기 + 운동 후 Summary 

### DIFF
--- a/pohang-egrets-Info.plist
+++ b/pohang-egrets-Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/pohang_egrets.xcodeproj/project.pbxproj
+++ b/pohang_egrets.xcodeproj/project.pbxproj
@@ -76,9 +76,10 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				App/pohang_egrets_watchApp.swift,
+				"App/pohang-egrets-watch-Watch-App-Info.plist",
 				"Preview Content/Preview Assets+Watch.xcassets",
 				"Resource/Assets+iPhone.xcassets",
-				Source/Domain/UseCase/Watch/LiveWorkout.swift,
+				Source/Domain/UseCase/Watch/LiveWorkoutUseCase.swift,
 				Source/Presentation/Watch/Main/View/MainView.swift,
 				Source/Presentation/Watch/Main/ViewModel/MainViewModel.swift,
 				"Source/Test/pohang_egrets_watch Watch AppTests/pohang_egrets_watch_Watch_AppTests.swift",
@@ -126,7 +127,9 @@
 				App/pohang_egrets_watchApp.swift,
 				"Preview Content/Preview Assets+Watch.xcassets",
 				"Resource/Assets+iPhone.xcassets",
-				Source/Domain/UseCase/Watch/LiveWorkout.swift,
+				Source/Domain/Entity/WorkoutSummary.swift,
+				Source/Domain/UseCase/Shared/FormatDateUseCase.swift,
+				Source/Domain/UseCase/Watch/LiveWorkoutUseCase.swift,
 				Source/Presentation/Watch/Main/View/MainView.swift,
 				Source/Presentation/Watch/Main/ViewModel/MainViewModel.swift,
 			);
@@ -647,9 +650,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"pohang_egrets/Preview Content\"";
-				DEVELOPMENT_TEAM = GKWM8Q6TMS;
+				DEVELOPMENT_TEAM = LLTXZL34C3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "pohang-egrets-Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -677,9 +681,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"pohang_egrets/Preview Content\"";
-				DEVELOPMENT_TEAM = GKWM8Q6TMS;
+				DEVELOPMENT_TEAM = LLTXZL34C3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "pohang-egrets-Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -779,10 +784,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"pohang_egrets/Preview Content\"";
-				DEVELOPMENT_TEAM = GKWM8Q6TMS;
+				DEVELOPMENT_TEAM = LLTXZL34C3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "pohang_egrets/App/pohang-egrets-watch-Watch-App-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = pohang_egrets_watch;
+				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "사용자의 운동을 도와주기 위해서";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "사용자의 운동을 도와주기 위해서";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "사용자의 운동을 도와주기 위해서";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "com.WanJaeLee.pohang-egrets";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -809,10 +818,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"pohang_egrets/Preview Content\"";
-				DEVELOPMENT_TEAM = GKWM8Q6TMS;
+				DEVELOPMENT_TEAM = LLTXZL34C3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "pohang_egrets/App/pohang-egrets-watch-Watch-App-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = pohang_egrets_watch;
+				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "사용자의 운동을 도와주기 위해서";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "사용자의 운동을 도와주기 위해서";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "사용자의 운동을 도와주기 위해서";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "com.WanJaeLee.pohang-egrets";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/pohang_egrets.xcodeproj/project.pbxproj
+++ b/pohang_egrets.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		6BD9ADB42CC417AA00B26B8C /* pohang_egrets_watch Watch App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "pohang_egrets_watch Watch App.entitlements"; sourceTree = "<group>"; };
 		CC134E452CC362A8000599FF /* pohang_egrets.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = pohang_egrets.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC134E552CC362A9000599FF /* pohang_egretsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = pohang_egretsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC134E5F2CC362A9000599FF /* pohang_egretsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = pohang_egretsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -202,6 +203,7 @@
 		CC134E3C2CC362A8000599FF = {
 			isa = PBXGroup;
 			children = (
+				6BD9ADB42CC417AA00B26B8C /* pohang_egrets_watch Watch App.entitlements */,
 				CC134E472CC362A8000599FF /* pohang_egrets */,
 				CC134E462CC362A8000599FF /* Products */,
 			);
@@ -781,6 +783,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "pohang_egrets_watch Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"pohang_egrets/Preview Content\"";
@@ -815,6 +818,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "pohang_egrets_watch Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"pohang_egrets/Preview Content\"";

--- a/pohang_egrets/App/pohang-egrets-watch-Watch-App-Info.plist
+++ b/pohang_egrets/App/pohang-egrets-watch-Watch-App-Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array/>
+	<key>WKBackgroundModes</key>
+	<array>
+		<string>workout-processing</string>
+	</array>
+</dict>
+</plist>

--- a/pohang_egrets/Source/Domain/Entity/WorkoutSummary.swift
+++ b/pohang_egrets/Source/Domain/Entity/WorkoutSummary.swift
@@ -1,0 +1,14 @@
+//
+//  WorkoutSummary.swift
+//  pohang_egrets
+//
+//  Created by Hyun Lee on 10/20/24.
+//
+
+import Foundation
+
+struct WorkoutSummary {
+    var averageHeartRate: String
+    var timeExercised: String
+    var totalCalories: String
+}

--- a/pohang_egrets/Source/Domain/UseCase/Shared/FormatDateUseCase.swift
+++ b/pohang_egrets/Source/Domain/UseCase/Shared/FormatDateUseCase.swift
@@ -1,0 +1,15 @@
+//
+//  FormatDateUseCase.swift
+//  pohang_egrets
+//
+//  Created by Hyun Lee on 10/20/24.
+//
+
+import Foundation
+
+var durationFormatter: DateComponentsFormatter = {
+    let formatter = DateComponentsFormatter()
+    formatter.allowedUnits = [.hour, .minute, .second]
+    formatter.zeroFormattingBehavior = .pad
+    return formatter
+}()

--- a/pohang_egrets/Source/Domain/UseCase/Shared/WorkoutSummaryUseCase.swift
+++ b/pohang_egrets/Source/Domain/UseCase/Shared/WorkoutSummaryUseCase.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-class WorkoutSummary: ObservableObject {
+class WorkoutSummaryUseCase: ObservableObject {
     
 }

--- a/pohang_egrets/Source/Domain/UseCase/Watch/LiveWorkout.swift
+++ b/pohang_egrets/Source/Domain/UseCase/Watch/LiveWorkout.swift
@@ -1,8 +1,0 @@
-//
-//  LiveWorkout.swift
-//  pohang_egrets_watch Watch App
-//
-//  Created by LeeWanJae on 10/19/24.
-//
-
-import Foundation

--- a/pohang_egrets/Source/Domain/UseCase/Watch/LiveWorkoutUseCase.swift
+++ b/pohang_egrets/Source/Domain/UseCase/Watch/LiveWorkoutUseCase.swift
@@ -1,0 +1,171 @@
+//
+//  LiveWorkout.swift
+//  pohang_egrets_watch Watch App
+//
+//  Created by LeeWanJae on 10/19/24.
+//
+
+import Foundation
+import HealthKit
+
+class LiveWorkoutUseCase: NSObject, ObservableObject {
+    
+    @Published var showingSummaryView: Bool = false {
+        didSet {
+            if showingSummaryView == false {
+                resetWorkout()
+            }
+        }
+    }
+
+    let healthStore = HKHealthStore()
+    var session: HKWorkoutSession?
+    var builder: HKLiveWorkoutBuilder?
+
+    func requestAuthorization() {
+        let typesToShare: Set = [
+            HKQuantityType.workoutType()
+        ]
+
+        let typesToRead: Set = [
+            HKQuantityType.quantityType(forIdentifier: .heartRate)!,
+            HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned)!,
+            HKObjectType.activitySummaryType()
+        ]
+
+        healthStore.requestAuthorization(toShare: typesToShare, read: typesToRead) { (success, error) in
+           
+        }
+    }
+
+    // MARK: - Session State Control (Workout Session 시작, 중지, 종료)
+    
+    @Published var running = false
+    
+    func startWorkout(workoutType: HKWorkoutActivityType) {
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = workoutType
+        configuration.locationType = .outdoor
+
+        do {
+            session = try HKWorkoutSession(healthStore: healthStore, configuration: configuration)
+            builder = session?.associatedWorkoutBuilder()
+        } catch {
+            
+            return
+        }
+
+        session?.delegate = self
+        builder?.delegate = self
+        
+        builder?.dataSource = HKLiveWorkoutDataSource(healthStore: healthStore,
+                                                     workoutConfiguration: configuration)
+
+        let startDate = Date()
+        session?.startActivity(with: startDate)
+        builder?.beginCollection(withStart: startDate) { (success, error) in
+            
+        }
+    }
+
+    func togglePause() {
+        if running == true {
+            self.pause()
+        } else {
+            resume()
+        }
+    }
+
+    private func pause() {
+        session?.pause()
+    }
+
+    private func resume() {
+        session?.resume()
+    }
+
+    func endWorkout() {
+        session?.end()
+        showingSummaryView = true
+    }
+
+    // MARK: - Live Workout Metrics (Workout 실시간 데이터)
+    @Published var heartRate: Double = 0
+    @Published var averageHeartRate: Double = 0
+    @Published var workout: HKWorkout?
+
+    private func updateForStatistics(_ statistics: HKStatistics?) {
+        guard let statistics = statistics else { return }
+
+        DispatchQueue.main.async {
+            switch statistics.quantityType {
+            case HKQuantityType.quantityType(forIdentifier: .heartRate):
+                let heartRateUnit = HKUnit.count().unitDivided(by: HKUnit.minute())
+                self.heartRate = statistics.mostRecentQuantity()?.doubleValue(for: heartRateUnit) ?? 0
+                self.averageHeartRate = statistics.averageQuantity()?.doubleValue(for: heartRateUnit) ?? 0
+            default:
+                return
+            }
+        }
+    }
+
+    func resetWorkout() {
+        builder = nil
+        workout = nil
+        session = nil
+        heartRate = 0
+    }
+    
+    // MARK: - Summary of Workout Metrics (Workout 요약 데이터)
+    func summaryOfWorkout() -> WorkoutSummary {
+        return WorkoutSummary(averageHeartRate: averageHeartRate.formatted(.number.precision(.fractionLength(0))),
+                              timeExercised: durationFormatter.string(from: workout?.duration ?? 0.0) ?? "",
+                              totalCalories: Measurement(value: workout?.totalEnergyBurned?.doubleValue(for: .kilocalorie()) ?? 0,
+                                                         unit: UnitEnergy.kilocalories)
+                                        .formatted(.measurement(width: .abbreviated,
+                                                                usage: .workout,
+                                                                numberFormatStyle: .number.precision(.fractionLength(0)))))
+    }
+}
+
+// MARK: - HKWorkoutSessionDelegate (Workout session state 바뀔때 알려주는 delegate)
+extension LiveWorkoutUseCase: HKWorkoutSessionDelegate {
+    func workoutSession(_ workoutSession: HKWorkoutSession, didChangeTo toState: HKWorkoutSessionState,
+                        from fromState: HKWorkoutSessionState, date: Date) {
+        DispatchQueue.main.async {
+            self.running = toState == .running
+        }
+
+        if toState == .ended {
+            builder?.endCollection(withEnd: date) { (success, error) in
+                self.builder?.finishWorkout { (workout, error) in
+                    DispatchQueue.main.async {
+                        self.workout = workout
+                    }
+                }
+            }
+        }
+    }
+
+    func workoutSession(_ workoutSession: HKWorkoutSession, didFailWithError error: Error) {
+
+    }
+}
+
+// MARK: - HKLiveWorkoutBuilderDelegate (Workout session 수치 업데이트 될때 알려주는 delegate)
+extension LiveWorkoutUseCase: HKLiveWorkoutBuilderDelegate {
+    func workoutBuilderDidCollectEvent(_ workoutBuilder: HKLiveWorkoutBuilder) {
+
+    }
+
+    func workoutBuilder(_ workoutBuilder: HKLiveWorkoutBuilder, didCollectDataOf collectedTypes: Set<HKSampleType>) {
+        for type in collectedTypes {
+            guard let quantityType = type as? HKQuantityType else { return }
+
+            let statistics = workoutBuilder.statistics(for: quantityType)
+
+            updateForStatistics(statistics)
+        }
+    }
+}
+

--- a/pohang_egrets_watch Watch App.entitlements
+++ b/pohang_egrets_watch Watch App.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## ✅ 작업한 내용
 -  LiveWorkoutUseCase에 authorization, workout control (start, pause, resume, stop), live workout data 갖고오기, summary workout data 갖고오기 구현 
 - WorkoutSummary라는 Entity 추가 
 - FormatDateUseCase 추가 -> 날짜 포맷팅 위해서 
 - UseCase: WorkoutSummary -> WorkoutSummaryUseCase로 변경 (Entity랑 이름이 겹쳐서)

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - SummaryView로 어떻게 이동하실지 모르겠지만, 일단 운동이 끝나면, published된 showSummaryView가 변동하게 했습니다
 - 새로운 파일, 함수 이름이 직관적인지 
 - LiveWorkoutUseCase에서 븅서 사용해야할 함수가 어떤것인지 직관적인지 
 - 요번에 너무 두서 없게 코드를 쓰기 시작해서 커밋을 자주 조금씩 못한점... 양해 부탁드립니다.... 다음에는 더 작은 단위로 할게용...


## 💡 관련 이슈
- Resolved: #1
