### PR TITLE
Feat/#3 - UserAppData가 Firestore에 저장 되도록 함수 구현

### DIFF
--- a/AsyncC/Source/Data/Empty.swift
+++ b/AsyncC/Source/Data/Empty.swift
@@ -1,8 +1,0 @@
-//
-//  Empty.swift
-//  AsyncC
-//
-//  Created by LeeWanJae on 11/6/24.
-//
-
-import Foundation

--- a/AsyncC/Source/Data/Repositories/FirebaseRepository.swift
+++ b/AsyncC/Source/Data/Repositories/FirebaseRepository.swift
@@ -17,10 +17,23 @@ final class FirebaseRepository: FirebaseRepositoryProtocol
         epochSeconds: Int
     ) {
         let db = Firestore.firestore()
-        db.collection("userAppData").document(id).setData([
-            "userID": id,
-            "appData": ["appName": appName, "timeStamp": epochSeconds]
-        ])
+        let docRef = db.collection("userAppData").document(id)
+        docRef.getDocument { (document, error) in
+            if let document = document {
+                if document.exists {
+                    docRef.updateData([
+                        "appData": FieldValue.arrayUnion([["appName": appName, "timeStamp": epochSeconds]])
+                    ])
+                } else {
+                    db.collection("userAppData").document(id).setData([
+                        "userID": id,
+                        "appData": [["appName": appName, "timeStamp": epochSeconds]]
+                    ])
+                }
+            } else {
+                print("Error: \(error?.localizedDescription ?? "No error description")")
+            }
+        }
     }
     
 }

--- a/AsyncC/Source/Data/Repositories/FirebaseRepository.swift
+++ b/AsyncC/Source/Data/Repositories/FirebaseRepository.swift
@@ -1,0 +1,26 @@
+//
+//  Empty.swift
+//  AsyncC
+//
+//  Created by LeeWanJae on 11/6/24.
+//
+
+import Foundation
+import FirebaseCore
+import FirebaseFirestore
+
+final class FirebaseRepository: FirebaseRepositoryProtocol
+{
+    func setUserAppData(
+        id: String,
+        appName: String,
+        epochSeconds: Int
+    ) {
+        let db = Firestore.firestore()
+        db.collection("userAppData").document(id).setData([
+            "userID": id,
+            "appData": ["appName": appName, "timeStamp": epochSeconds]
+        ])
+    }
+    
+}

--- a/AsyncC/Source/Data/Repositories/LocalRepository.swift
+++ b/AsyncC/Source/Data/Repositories/LocalRepository.swift
@@ -1,0 +1,21 @@
+//
+//  LocalRepository.swift
+//  AsyncC
+//
+//  Created by Hyun Lee on 11/6/24.
+//
+
+import SwiftUI
+
+final class LocalRepository: LocalRepositoryProtocol {
+    @AppStorage("userID") var userID: String = "mia"
+    
+    func getUserID() -> String {
+        return userID
+    }
+    
+    func saveUserID(_ inputID: String) {
+        self.userID = inputID
+    }
+    
+}

--- a/AsyncC/Source/Domain/Entity/UserAppData.swift
+++ b/AsyncC/Source/Domain/Entity/UserAppData.swift
@@ -9,5 +9,5 @@ import Foundation
 
 struct UserAppData { // Write: user 본인꺼만 write 가능, Read: 모든 user
     let userID: String //UUID
-    var appData: [(String, String)] // (앱 이름, 타임스탬프), 타임스탬프는 로컬에서 연산 필요
+    var appData: [(String, Int)] // (앱 이름, Epoch time), Epoch time 이란? 1970년 1월1일 부터 흐른 seconds (IT에서 자주 쓰이는 시간 측정 방법)
 }

--- a/AsyncC/Source/Domain/RepositoryInterfaces/FirebaseRepositoryProtocol.swift
+++ b/AsyncC/Source/Domain/RepositoryInterfaces/FirebaseRepositoryProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  FirebaseRepositoryProtocol.swift
+//  AsyncC
+//
+//  Created by Hyun Lee on 11/6/24.
+//
+
+protocol FirebaseRepositoryProtocol {
+    
+    func setUserAppData(id: String,
+                     appName: String,
+                     epochSeconds: Int) -> Void
+}

--- a/AsyncC/Source/Domain/RepositoryInterfaces/LocalRepositoryProtocol.swift
+++ b/AsyncC/Source/Domain/RepositoryInterfaces/LocalRepositoryProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  LocalRepositoryProtocol.swift
+//  AsyncC
+//
+//  Created by Hyun Lee on 11/6/24.
+//
+
+protocol LocalRepositoryProtocol {
+    
+    func getUserID() -> String
+    
+    func saveUserID(_ inputID: String)
+    
+}

--- a/AsyncC/Source/Domain/UseCases/AccountManagingUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/AccountManagingUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  AccountManagingUseCase.swift
+//  AsyncC
+//
+//  Created by Hyun Lee on 11/6/24.
+//
+
+import Foundation
+
+final class AccountManagingUseCase {
+    
+    private let localRepository: LocalRepository
+    
+    init() {
+        localRepository = LocalRepository()
+    }
+    
+    private func saveUserIDToLocal(userID: String) {
+        localRepository.saveUserID(userID)
+    }
+    
+}

--- a/AsyncC/Source/Domain/UseCases/AppTrackingUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/AppTrackingUseCase.swift
@@ -10,19 +10,21 @@ import Foundation
 final class AppTrackingUseCase {
     
     private let firebaseRepository: FirebaseRepository
+    private let localRepository: LocalRepository
     
     init() {
         firebaseRepository = FirebaseRepository()
+        localRepository = LocalRepository()
     }
     
-    func updateAppTracking(appName: String) {
-        let id = getUserID()
+    private func updateAppTracking(appName: String) {
+        let id = getUserIDFromLocal()
         let epochSeconds = Int(Date().timeIntervalSince1970)
         firebaseRepository.setUserAppData(id: id, appName: appName, epochSeconds: epochSeconds)
     }
     
-    func getUserID() -> String {
-        // Data layer에서 user default 갖고오기
-        return "mia"
+    private func getUserIDFromLocal() -> String {
+        return localRepository.getUserID()
     }
+    
 }

--- a/AsyncC/Source/Domain/UseCases/AppTrackingUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/AppTrackingUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  AppTrackingUseCase.swift
+//  AsyncC
+//
+//  Created by Hyun Lee on 11/6/24.
+//
+
+import Foundation
+
+final class AppTrackingUseCase {
+    
+    private let firebaseRepository: FirebaseRepository
+    
+    init() {
+        firebaseRepository = FirebaseRepository()
+    }
+    
+    func updateAppTracking(appName: String) {
+        let id = getUserID()
+        let epochSeconds = Int(Date().timeIntervalSince1970)
+        firebaseRepository.setUserAppData(id: id, appName: appName, epochSeconds: epochSeconds)
+    }
+    
+    func getUserID() -> String {
+        // Data layer에서 user default 갖고오기
+        return "mia"
+    }
+}


### PR DESCRIPTION
## ✅ 작업한 내용
 - LocalRepository, LocalRepositoryProtocol 구현 -> 사용자의 UserID를 user default에 저장하고 필요할때 갖고 오기 위해서 
 - FirebaseRepository, FirebaseRepositoryProtocol 구현 -> 이 repository를 통해, 사용자의 활성화된 앱이 바뀔때, ID를 받아오고, 그 ID와 맞는 firestore에 있는 UserAppData를 update (array에 추가) . 만약 user의 appData 객체가 존재하지 않으면, 만든다.
 - 쉬운 연산을 위해서 시간을 epoch time (Int)로 바꿨습니다: Epoch time 이란? 1970년 1월1일 부터 흐른 seconds (IT에서 자주 쓰이는 시간 측정 방법). 이렇게 하면 저희가 그냥 초단위로 산수 하면 되니까 이렇게 수정했습니다.

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - 아키텍처에 맞게 구현이 됬는지 
 - 이해가 되게 명확한 구현이 됬는지
 - Epoch time으로 변환 괜찮은지

- Resolved: #3
