### PR TITLE
Feat/#6 - UserAppData Listener 구현 + use case에서 필요한 정보로 정리

### DIFF
--- a/AsyncC/Source/Data/Repositories/FirebaseRepository.swift
+++ b/AsyncC/Source/Data/Repositories/FirebaseRepository.swift
@@ -36,4 +36,42 @@ final class FirebaseRepository: FirebaseRepositoryProtocol
         }
     }
     
+    func setUpListenerForUserAppData(userID: String, handler: @escaping (Result<UserAppData, any Error>) -> Void) {
+        let db = Firestore.firestore()
+        let docRef = db.collection("userAppData").document(userID)
+        
+        docRef
+            .addSnapshotListener { (documentSnapshot, error) in
+                guard let document = documentSnapshot else {
+                    if let error {
+                        handler(.failure(error))
+                    } else {
+                        print("Error fetching document")
+                    }
+                    return
+                }
+                guard let data = document.data() else {
+                    if let error {
+                        handler(.failure(error))
+                    } else {
+                        print("Document data was empty.")
+                    }
+                    return
+                }
+                
+                let appDataTuples: [(String, Int)] = (data["appData"] as? [[String: Any]])?.compactMap { entry in
+                    if let appName = entry["appName"] as? String,
+                       let timeStamp = entry["timeStamp"] as? Int {
+                        return (appName, timeStamp)
+                    } else {
+                        return nil
+                    }
+                } ?? []
+                if !appDataTuples.isEmpty, let id = data["userID"] as? String {
+                    handler(.success(UserAppData(userID: id, appData: appDataTuples)))
+                }
+            }
+        
+    }
+    
 }

--- a/AsyncC/Source/Domain/RepositoryInterfaces/FirebaseRepositoryProtocol.swift
+++ b/AsyncC/Source/Domain/RepositoryInterfaces/FirebaseRepositoryProtocol.swift
@@ -10,4 +10,6 @@ protocol FirebaseRepositoryProtocol {
     func setUserAppData(id: String,
                      appName: String,
                      epochSeconds: Int) -> Void
+    
+    func setUpListenerForUserAppData(userID: String, handler: @escaping (Result<UserAppData, Error>) -> Void)
 }

--- a/AsyncC/Source/Domain/UseCases/AppTrackingUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/AppTrackingUseCase.swift
@@ -7,10 +7,12 @@
 
 import Foundation
 
-final class AppTrackingUseCase {
+final class AppTrackingUseCase: ObservableObject {
     
     private let firebaseRepository: FirebaseRepository
     private let localRepository: LocalRepository
+    private var teamMemberIDs = ["ingt", "mia", "topia"] // 추후에 팀 생성 + 팀 정보 갖고오기 하면 바꿀 예정
+    @Published var teamMemberAppTrackings: [String: [String]] = [:]
     
     init() {
         firebaseRepository = FirebaseRepository()
@@ -25,6 +27,39 @@ final class AppTrackingUseCase {
     
     private func getUserIDFromLocal() -> String {
         return localRepository.getUserID()
+    }
+    
+    func setupAppTracking() {
+        for member in teamMemberIDs {
+            firebaseRepository.setUpListenerForUserAppData(userID: member) { result in
+                switch result {
+                case .success(let appData):
+                    self.updateAppTracking(with: appData)
+                case .failure(let error):
+                    print(error)
+                }
+            }
+        }
+    }
+    
+    private func updateAppTracking(with updatedData: UserAppData) {
+        let userID = updatedData.userID
+        var appData = updatedData.appData
+        var arrayOfLatestApps = [String](repeating: "", count: 5)
+        var count = min(4, appData.count - 1)
+        var uniqueApps: Set<String> = []
+        
+        while count >= 0 {
+            let appName = appData.removeLast().0
+            if !uniqueApps.contains(appName) {
+                uniqueApps.insert(appName)
+                arrayOfLatestApps[count] = appName
+            }
+            count -= 1
+        }
+        arrayOfLatestApps.removeAll(where: {$0 == ""})
+        teamMemberAppTrackings[userID] = arrayOfLatestApps
+        print(teamMemberAppTrackings)
     }
     
 }


### PR DESCRIPTION
## ✅ 작업한 내용
 - (임시 케스트 데이터) team에 포함된 user id를 사용하여, team에 있는 user에게 listener 달기
 - user의 app data가 바뀌었을때, appData를 받아서 최근 사용된 앱 5개를 중복 없이 정리하고, `@Published` property에 update 시켜줌

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 -

## 💡 관련 이슈
- Resolved: #6
