### PR TITLE
[#13] - Emoticon UseCase 구현

### DIFF
--- a/AsyncC/Source/Data/Repositories/FirebaseRepository.swift
+++ b/AsyncC/Source/Data/Repositories/FirebaseRepository.swift
@@ -56,6 +56,26 @@ final class FirebaseRepository: FirebaseRepositoryProtocol
         }
     }
     
+    func sendEmoticon(
+        sender: String,
+        emoticon: String,
+        receiver: String
+    ) {
+        let db = Firestore.firestore()
+        let docRef = db.collection("emoticons").document(receiver)
+        docRef.getDocument { (document, error) in
+            if let document = document {
+                db.collection("emoticons").document(receiver).setData([
+                    "sender": sender,
+                    "emoticon": emoticon,
+                    "receiver": receiver
+                ])
+            } else {
+                print("Error: \(error?.localizedDescription ?? "No error description")")
+            }
+        }
+    }
+    
     func setUpListenerForUserAppData(userID: String, handler: @escaping (Result<UserAppData, any Error>) -> Void) {
         let db = Firestore.firestore()
         let docRef = db.collection("userAppData").document(userID)
@@ -92,6 +112,42 @@ final class FirebaseRepository: FirebaseRepositoryProtocol
                 }
             }
         
+    }
+    
+    func setUpListenerForEmoticons(userID: String, handler: @escaping (Result<Emoticon, any Error>) -> Void) {
+        let db = Firestore.firestore()
+        let docRef = db.collection("emoticons").document(userID)
+        
+        docRef
+            .addSnapshotListener { (documentSnapshot, error) in
+                guard let document = documentSnapshot else {
+                    if let error {
+                        handler(.failure(error))
+                    } else {
+                        print("Error fetching document")
+                    }
+                    return
+                }
+                
+                guard let data = document.data() else {
+                    if let error {
+                        handler(.failure(error))
+                    } else {
+                        print("Document data was empty.")
+                    }
+                    return
+                }
+                
+                guard let sender = data["sender"] as? String,
+                      let receiver = data["receiver"] as? String,
+                      let emoticonRawValue = data["emoticon"] as? String,
+                      let emoticonOption = Emoticon.emoticonOption(rawValue: emoticonRawValue) else {
+                    let mappingError = NSError(domain: "MappingError", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid data format"])
+                    handler(.failure(mappingError))
+                    return
+                }
+                handler(.success(Emoticon(receiver: receiver, emoticon: emoticonOption, sender: sender)))
+            }
     }
     
 }

--- a/AsyncC/Source/Domain/Entity/Emoticon.swift
+++ b/AsyncC/Source/Domain/Entity/Emoticon.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-struct Emotion {
+struct Emoticon {
     var receiver: String // 받는이 UUID
-    var emotion: emotionOption?
+    var emoticon: emoticonOption
     var sender: String //보낸이 UUID
     
-    enum emotionOption {
+    enum emoticonOption: String {
         case getHelp
         case giveHelp
         case yes

--- a/AsyncC/Source/Domain/RepositoryInterfaces/FirebaseRepositoryProtocol.swift
+++ b/AsyncC/Source/Domain/RepositoryInterfaces/FirebaseRepositoryProtocol.swift
@@ -11,5 +11,15 @@ protocol FirebaseRepositoryProtocol {
                      appName: String,
                      epochSeconds: Int) -> Void
     
+    func setUsers(id: String,
+                  email: String,
+                  name: String) -> Void
+    
+    func sendEmoticon(sender: String,
+                      emoticon: String,
+                      receiver: String) -> Void
+    
     func setUpListenerForUserAppData(userID: String, handler: @escaping (Result<UserAppData, Error>) -> Void)
+    
+    func setUpListenerForEmoticons(userID: String, handler: @escaping (Result<Emoticon, any Error>) -> Void)
 }

--- a/AsyncC/Source/Domain/UseCases/EmoticonUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/EmoticonUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  EmoticonUseCase.swift
+//  AsyncC
+//
+//  Created by Jin Lee on 11/8/24.
+//
+
+import Foundation
+
+final class EmoticonUseCase {
+    private let firebaseRepository: FirebaseRepository
+    private let localRepository: LocalRepository
+    
+    init() {
+        firebaseRepository = FirebaseRepository()
+        localRepository = LocalRepository()
+    }
+    
+    func send(emoticon: Emoticon.emoticonOption, receiver: String) {
+        let sender = localRepository.getUserID()
+        firebaseRepository.sendEmoticon(sender: sender, emoticon: emoticon.rawValue, receiver: receiver)
+    }
+    
+    func setUpListenerForEmoticons(userID: String) {
+        firebaseRepository.setUpListenerForEmoticons(userID: userID) { result in
+            print(result)
+        }
+    }
+}


### PR DESCRIPTION
## ✅ 작업한 내용
 - Emoticon UseCase 구현

### FirebaseRepository
- [x] sendEmoticon
- [x] setUpListenerForEmoticons
- [x] 프로토콜 작성
### Emoticon
- [x] Emotion -> Emoticon 모델명 수정
### Emoticon UseCase
- [x] send
- [x] setUpListenerForEmoticons

## 💡 관련 이슈
- Resolved: #13 
