### PR TITLE
[#52] - CheckToJoinTeam 구현, 팀이 없으면 에러 메세지 띄우기

### DIFF
--- a/AsyncC/Source/Presentation/CheckToJoinTeam/CheckToJoinTeamView.swift
+++ b/AsyncC/Source/Presentation/CheckToJoinTeam/CheckToJoinTeamView.swift
@@ -1,0 +1,48 @@
+//
+//  CheckToJoinTeamView.swift
+//  AsyncC
+//
+//  Created by Hyun Lee on 11/18/24.
+//
+
+import SwiftUI
+
+struct CheckToJoinTeamView: View {
+    @EnvironmentObject var router: Router
+    
+    var viewModel: CheckToJoinTeamViewModel
+    
+    var teamCode: String
+    var teamName: String
+    var hostName: String
+    
+    var body: some View {
+        VStack(alignment: .center) {
+            Text("팀명")
+                .font(Font.system(size: 16, weight: .semibold))
+                .padding(EdgeInsets(top: 22, leading: 0, bottom: 0, trailing: 0))
+            Text(teamName)
+            Text("호스트")
+                .font(Font.system(size: 16, weight: .semibold))
+                .padding(EdgeInsets(top: 22, leading: 0, bottom: 0, trailing: 0))
+            Text(hostName)
+            HStack {
+                Spacer()
+                Button("취소") {
+                    router.pop()
+                }
+                Button("참여") {
+                    Task {
+                        await viewModel.addMemberToTeam(teamCode)
+                    }
+                    NSApplication.shared.keyWindow?.close()
+                    router.showHUDWindow()
+                }
+                .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 12))
+            }
+            .padding(EdgeInsets(top: 16, leading: 0, bottom: 0, trailing: 12))
+            Spacer()
+        }
+        .frame(width: 270, height: 200)
+    }
+}

--- a/AsyncC/Source/Presentation/CheckToJoinTeam/CheckToJoinTeamViewModel.swift
+++ b/AsyncC/Source/Presentation/CheckToJoinTeam/CheckToJoinTeamViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  CheckToJoinTeamViewModel.swift
+//  AsyncC
+//
+//  Created by Hyun Lee on 11/18/24.
+//
+
+
+import SwiftUI
+
+class CheckToJoinTeamViewModel: ObservableObject {
+    let teamManagingUseCase: TeamManagingUseCase
+    
+    init(teamManagingUseCase: TeamManagingUseCase) {
+        self.teamManagingUseCase = teamManagingUseCase
+    }
+    
+    func addMemberToTeam(_ code: String) async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                self.teamManagingUseCase.addNewMemberToTeam(teamCode: code)
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/AsyncC/Source/Presentation/Flow/Router.swift
+++ b/AsyncC/Source/Presentation/Flow/Router.swift
@@ -34,6 +34,7 @@ class Router: ObservableObject{
         case JoinTeamView
         case MainStatusView
         case LoginView
+        case CheckToJoinTeamView(teamCode: String, teamName: String, hostName: String)
     }
     
     @ViewBuilder func view(for route: AsyncCViews) -> some View {
@@ -48,6 +49,11 @@ class Router: ObservableObject{
             MainStatusView(viewModel: MainStatusViewModel(teamManagingUseCase: self.teamManagingUseCase, appTrackingUseCase: self.appTrackingUseCase))
         case .LoginView:
             LoginView(viewModel: LoginViewModel(accountManagingUseCase: accountManagingUseCase))
+        case .CheckToJoinTeamView(let teamCode, let teamName, let hostName):
+            CheckToJoinTeamView(viewModel: CheckToJoinTeamViewModel(teamManagingUseCase: teamManagingUseCase),
+                                teamCode: teamCode,
+                                teamName: teamName,
+                                hostName: hostName)
         }
     }
     

--- a/AsyncC/Source/Presentation/JoinTeamView/JoinTeamViewModel.swift
+++ b/AsyncC/Source/Presentation/JoinTeamView/JoinTeamViewModel.swift
@@ -14,15 +14,6 @@ class JoinTeamViewModel: ObservableObject {
         self.teamManagingUseCase = teamManagingUseCase
     }
     
-    func addMemberToTeam(_ code: String) async {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                self.teamManagingUseCase.addNewMemberToTeam(teamCode: code)
-                continuation.resume()
-            }
-        }
-    }
-    
     func getDetailsOfTeam(_ code: String, handler: @escaping (Result<(teamName: String, hostName: String), Error>) -> Void)  {
         teamManagingUseCase.getTeamNameAndHostName(for: code) { result in
             handler(result)


### PR DESCRIPTION
## ✅ 작업한 내용
 - JoinTeamView 에서 host이름, team 이름 찾고 CheckToJoinTeamView에 넘겨주기 
 - CheckToJoinTeamView에 팀이름, 호스트 이름 보여주기 
 - CheckToJoinTeamView에서 참여버튼 누르면 팀에 합류하고 바로 status bar panel 띄우기
 - Error handling: 만약 JoinTeamView에서 기존에 없는 TeamCode를 입력하면 alert이 뜸

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - JoinTeamView에서 CheckToJoinTeamView 넘어갈때 여러 parameter를 넘겨주는데, router에서 enum parameter 사용함. 이게 좋은 방법인지는 모르겠어요~ 만약 더 좋은 방법이 있으면 feedback 부탁합니다.
 - 다시 해보니 team이 있어도 alert가 먼저 띄어지고 다음 CheckToJoinView로 넘어가네요.. 다음 이슈에 수정하겠습니다.

## 📸 스크린샷
<img width="271" alt="Screenshot 2024-11-18 at 11 58 40 am" src="https://github.com/user-attachments/assets/ffdfaacc-3ca0-419f-8a2e-64c10038e718">
<img width="273" alt="Screenshot 2024-11-18 at 11 59 28 am" src="https://github.com/user-attachments/assets/6b78239c-5401-42eb-9eac-7e8d3bf0afe6">


## 💡 관련 이슈
- Resolved: #52
