### PR TITLE
[#59] 메인 판넬 정렬 수정, 팀 코드 복사 수정, 방 나가기 이후 앱 크래쉬 해결

### DIFF
--- a/AsyncC/Source/Data/Repositories/LocalRepository.swift
+++ b/AsyncC/Source/Data/Repositories/LocalRepository.swift
@@ -10,8 +10,17 @@ import SwiftUI
 final class LocalRepository: LocalRepositoryProtocol {
     @AppStorage("userID") var userID: String = ""
     @AppStorage("userName") var userName: String = ""
-    @AppStorage("teamCode") var teamCode: String = ""
     @AppStorage("teamName") var teamName: String = ""
+    @AppStorage("teamCode") private var _teamCode: String = ""
+
+    var teamCode: String? {
+        get {
+            _teamCode.isEmpty ? nil : _teamCode
+        }
+        set {
+            _teamCode = newValue ?? ""
+        }
+    }
     
     func getUserID() -> String {
         return userID
@@ -34,7 +43,7 @@ final class LocalRepository: LocalRepositoryProtocol {
     }
     
     func getTeamCode() -> String {
-        return teamCode
+        return teamCode ?? "pocmio"
     }
     
     func resetTeamCode() {

--- a/AsyncC/Source/Domain/RepositoryInterfaces/LocalRepositoryProtocol.swift
+++ b/AsyncC/Source/Domain/RepositoryInterfaces/LocalRepositoryProtocol.swift
@@ -9,7 +9,7 @@ protocol LocalRepositoryProtocol {
     
     var userID: String { get set }
     var userName: String { get set }
-    var teamCode: String { get set }
+    var teamCode: String? { get set }
     var teamName: String { get set }
     
     func getUserID() -> String

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
@@ -12,7 +12,7 @@ struct AppTrackingBoxView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            ForEach(viewModel.appTrackings.keys.sorted(), id: \.self) { key in
+            ForEach(viewModel.appTrackings.keys.sorted(by: viewModel.customSort), id: \.self) { key in
                 HStack(spacing: 0) {
                     VStack(spacing: 0) {
                         if key == viewModel.hostName {
@@ -42,25 +42,33 @@ struct AppTrackingBoxView: View {
                         .frame(width: 130, height: 40)
                         .overlay {
                             HStack(spacing: 0) {
+                                Spacer()
+                                    .frame(width: 5)
                                 ForEach(viewModel.appTrackings[key] ?? [], id:\.self) { appName in
                                     Image("\(appName)")
                                         .resizable()
                                         .scaledToFit()
-                                        .frame(width: 25, height: 25)
+                                        .frame(width: 32, height: 32)
                                         .opacity(viewModel.getOpacity(appName: appName, apps: viewModel.appTrackings[key] ?? []))
-                                        .padding(.leading, 12)
+                                        .padding(.leading, 5)
                                 }
                                 Spacer()
                             }
                         }
                         .padding(.trailing, 6)
+                        .padding(.bottom, 8)
                     
                     if viewModel.getUserName() == key {
                         createButton(title: "손 들기", width: 100, height: 40, size: 16, action: {})
+                            .padding(.bottom, 8)
+
                     } else {
                         createButton(title: "콕 찌르기", width: 48, height: 40, size: 12, action: {})
                             .padding(.trailing, 4)
+                            .padding(.bottom, 8)
                         createButton(title: "손 든 거에 반응하기", width: 48, height: 40, size: 12, action: {})
+                            .padding(.bottom, 8)
+
                     }
                 }
                 

--- a/AsyncC/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
@@ -24,7 +24,6 @@ struct TeamCodeView: View {
                     Button {
                         viewModel.isMenuVisible.toggle()
                         viewModel.leaveTeam()
-                        router.push(view: .CreateOrJoinTeamView)
                     } label: {
                         Image(systemName: "chevron.right")
                             .resizable()

--- a/AsyncC/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
@@ -28,8 +28,7 @@ struct TeamCodeView: View {
                     .padding(.trailing, 2)
                 
                 Button {
-                    let pasteboard = NSPasteboard.general
-                    pasteboard.setString(viewModel.getTeamCode(), forType: .string)
+                    viewModel.copyTeamCode()
                 } label: {
                     Image(systemName: "document.on.document")
                         .resizable()

--- a/AsyncC/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
@@ -9,14 +9,33 @@ import SwiftUI
 
 struct TeamCodeView: View {
     @ObservedObject var viewModel: MainStatusViewModel
+    @EnvironmentObject var router: Router
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(viewModel.getTeamName())
-                .font(.system(size: 20, weight: .medium))
-                .padding(.horizontal, 16)
-                .padding(.top, 20)
-                .foregroundStyle(.darkGray2)
+            HStack {
+                Text(viewModel.getTeamName())
+                    .font(.system(size: 20, weight: .medium))
+                    .padding(.horizontal, 16)
+                    .foregroundStyle(.darkGray2)
+                
+                Spacer()
+                
+                    Button {
+                        viewModel.isMenuVisible.toggle()
+                        viewModel.leaveTeam()
+                        router.push(view: .CreateOrJoinTeamView)
+                    } label: {
+                        Image(systemName: "chevron.right")
+                            .resizable()
+                            .scaledToFit()
+                            .foregroundStyle(.darkGray1)
+                            .frame(width: 5, height: 10)
+                    }
+                    .buttonStyle(.plain)
+            }
+            .padding(.top, 20)
+
             
             HStack(alignment: .bottom, spacing: 0){
                 Text("팀 코드:")

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
@@ -39,8 +39,7 @@ struct MainStatusView: View {
             .onAppear {
                 print("App Tracking: \(viewModel.appTrackings)")
                 viewModel.startShowingAppTracking()
-//                viewModel.getTeamData(teamCode: viewModel.getTeamCode())
-                viewModel.getTeamData(teamCode: "pacmio")
+                viewModel.getTeamData(teamCode: viewModel.getTeamCode())
                 viewModel.checkHost()
             }
         }

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
@@ -39,7 +39,8 @@ struct MainStatusView: View {
             .onAppear {
                 print("App Tracking: \(viewModel.appTrackings)")
                 viewModel.startShowingAppTracking()
-                viewModel.getTeamData(teamCode: viewModel.getTeamCode())
+//                viewModel.getTeamData(teamCode: viewModel.getTeamCode())
+                viewModel.getTeamData(teamCode: "pacmio")
                 viewModel.checkHost()
             }
         }

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
@@ -130,4 +130,11 @@ class MainStatusViewModel: ObservableObject {
         
         return lhs < rhs
     }
+    
+    func copyTeamCode() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(self.getTeamCode(), forType: .string)
+        print("팀 코드 복사")
+    }
 }

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
@@ -115,6 +115,19 @@ class MainStatusViewModel: ObservableObject {
     }
     
     func containsXcode(apps: [String]) -> Bool {
-        return apps.contains("Xcode")
+        if apps.firstIndex(of: "Xcode") == 0 {
+            return true
+        }
+        return false
+    }
+    
+    func customSort(lhs: String, rhs: String) -> Bool {
+        if lhs == self.getUserName() { return true }
+        if rhs == self.getUserName() { return false }
+        
+        if lhs == self.hostName { return true }
+        if rhs == self.hostName { return false }
+        
+        return lhs < rhs
     }
 }

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
@@ -26,7 +26,8 @@ class MainStatusViewModel: ObservableObject {
     @Published var hostName: String = ""
     @Published var teamMembers: [String] = []
     @Published var isTeamHost: Bool = false
-    
+    @Published var isMenuVisible: Bool = false
+
     init(teamManagingUseCase: TeamManagingUseCase, appTrackingUseCase: AppTrackingUseCase) {
         self.teamManagingUseCase = teamManagingUseCase
         self.appTrackingUseCase = appTrackingUseCase


### PR DESCRIPTION
## ✅ 작업한 내용
 -  메인 판넬 정렬 수정
 -  팀 코드 복사 수정
 - 방 나가기 이후 앱 크래쉬 해결

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - 지금 방 나가기 이후에 리다이랙션 되는 부분이 없습니다.
 - statusBar가 없어지면서 다시 윈도우 창으로 옮겨 가야되는 로직으로 구현할 생각입니다.

## 📸 스크린샷
<img width="270" alt="스크린샷 2024-11-19 오전 12 06 41" src="https://github.com/user-attachments/assets/25457e7b-5c60-4e8f-a62c-3e716bd77466">
방 나가기 하면 이렇게 리다이랙션 화면이 없어서 일단 빈칸으로 됩니다.

## 💡 관련 이슈
- Resolved: #59 
