### PR TITLE
[#64] StatusMainBar 재구현

### DIFF
--- a/AsyncC/Resource/Assets.xcassets/Color/ButtonDefault.colorset/Contents.json
+++ b/AsyncC/Resource/Assets.xcassets/Color/ButtonDefault.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "0.478",
-          "red" : "0.000"
+          "alpha" : "0.500",
+          "blue" : "0x7F",
+          "green" : "0x7F",
+          "red" : "0x7F"
         }
       },
       "idiom" : "universal"

--- a/AsyncC/Resource/Assets.xcassets/Color/ButtonStroke.colorset/Contents.json
+++ b/AsyncC/Resource/Assets.xcassets/Color/ButtonStroke.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA6",
+          "green" : "0xA6",
+          "red" : "0xA6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AsyncC/Source/Extension/Extension + HUDWindow.swift
+++ b/AsyncC/Source/Extension/Extension + HUDWindow.swift
@@ -34,6 +34,8 @@ extension AppDelegate {
         hudWindow?.contentView?.wantsLayer = true
         hudWindow?.contentView?.layer?.cornerRadius = 5.0
         hudWindow?.contentView?.layer?.masksToBounds = true
+        
+        hudWindow?.appearance = NSAppearance(named: .aqua)
     }
     
     func showHUDWindow() {

--- a/AsyncC/Source/Presentation/ContentView.swift
+++ b/AsyncC/Source/Presentation/ContentView.swift
@@ -26,7 +26,7 @@ struct ContentView: View {
                 router.view(for: destination)
             }
             .navigationBarBackButtonHidden(true)
-        }        
+        }
     }
 }
 

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
@@ -64,7 +64,7 @@ struct AppTrackingBoxView: View {
                                 }
                             }
                         }
-                        .padding(.trailing, viewModel.checkUser(key: key) ? 0 : 6)
+                        .padding(.trailing, viewModel.checkUser(key: key) ? 0 : 4)
                     
                     if viewModel.getUserName() != key {
                         createButton(key: "\(key)-sos", symbol: "sos", width: 27, height: 12, text: "도움요청", action: {})

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
@@ -23,7 +23,7 @@ struct AppTrackingBoxView: View {
                                 HStack(spacing: 0) {
                                     Text(key)
                                         .font(.system(size: 12, weight: .medium))
-                                        .foregroundStyle(.darkGray1)
+                                        .foregroundStyle(.black)
                                         .padding(.trailing, 4)
                                     
                                     if key == viewModel.hostName {

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
@@ -57,10 +57,9 @@ struct AppTrackingBoxView: View {
                                             .scaledToFit()
                                             .frame(width: 32, height: 32)
                                             .opacity(viewModel.getOpacity(appName: appName, apps: viewModel.appTrackings[key] ?? []))
-                                            .padding(.horizontal, 8)
-                                            .padding(.top, 4)
-                                            .padding(.bottom, 8)
                                     }
+                                    .padding(.horizontal, 8)
+                                    .padding(.bottom, 8)
                                     Spacer()
                                 }
                             }
@@ -77,7 +76,7 @@ struct AppTrackingBoxView: View {
                 
                 if key == viewModel.getUserName() {
                     Divider()
-                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
                 }
             }
             .padding(.horizontal, 16)

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
@@ -14,67 +14,70 @@ struct AppTrackingBoxView: View {
         VStack(spacing: 0) {
             ForEach(viewModel.appTrackings.keys.sorted(by: viewModel.customSort), id: \.self) { key in
                 HStack(spacing: 0) {
-                    VStack(spacing: 0) {
-                        if key == viewModel.hostName {
-                            HostTagView()
-                        }
-                        
-                        Text(key)
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.darkGray1)
-                            .padding(.bottom, 8)
-                    }
-                    Spacer()
-                }
-                
-                HStack(spacing: 0) {
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(.lightGray1)
-                        .stroke(
-                            viewModel.containsXcode(
-                                apps: viewModel.appTrackings[key] ?? []) ?
-                            Color("SystemBlue") : Color("LightGray2"),
-                            lineWidth: 0.5
-                        )
-                        .shadow(color:  viewModel.containsXcode(
-                            apps: viewModel.appTrackings[key] ?? []) ?
-                                Color("SystemBlue") : .black.opacity(0.2), radius: 4, x: 0, y: 0)
-                        .frame(width: 130, height: 40)
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(.regularMaterial)
+                        .frame(width: viewModel.checkUser(key: key) ? 243 : 140, height: 68)
+                        .shadow(color: .black.opacity(0.25), radius: 6, x: 1, y: 1)
                         .overlay {
-                            HStack(spacing: 0) {
-                                Spacer()
-                                    .frame(width: 5)
-                                ForEach(viewModel.appTrackings[key] ?? [], id:\.self) { appName in
-                                    Image("\(appName)")
-                                        .resizable()
-                                        .scaledToFit()
-                                        .frame(width: 32, height: 32)
-                                        .opacity(viewModel.getOpacity(appName: appName, apps: viewModel.appTrackings[key] ?? []))
-                                        .padding(.leading, 5)
+                            VStack(spacing: 0) {
+                                HStack(spacing: 0) {
+                                    Text(key)
+                                        .font(.system(size: 12, weight: .medium))
+                                        .foregroundStyle(.darkGray1)
+                                        .padding(.trailing, 4)
+                                    
+                                    if key == viewModel.hostName {
+                                        HostTagView()
+                                    }
+                                    Spacer()
+                                    
+                                    if viewModel.checkUser(key: key) {
+                                        Toggle(isOn: $viewModel.isToggled) {
+                                            Text("")
+                                        }
+                                        .toggleStyle(SwitchToggleStyle(tint: .accent)) // 토글색 안바뀜
+                                        .padding(.trailing, 8)
+                                        .onChange(of: viewModel.isToggled) { old, new in
+                                            if new {
+                                                viewModel.startShowingAppTracking()
+                                            } else {
+                                                viewModel.stopAppTracking()
+                                            }
+                                        }
+                                    }
                                 }
-                                Spacer()
+                                .padding(.bottom, 4)
+                                .padding(.top, 8)
+                                .padding(.leading, 8)
+                                
+                                HStack(spacing: 0) {
+                                    ForEach(viewModel.appTrackings[key] ?? [], id:\.self) { appName in
+                                        Image("\(appName)")
+                                            .resizable()
+                                            .scaledToFit()
+                                            .frame(width: 32, height: 32)
+                                            .opacity(viewModel.getOpacity(appName: appName, apps: viewModel.appTrackings[key] ?? []))
+                                            .padding(.horizontal, 8)
+                                            .padding(.top, 4)
+                                            .padding(.bottom, 8)
+                                    }
+                                    Spacer()
+                                }
                             }
                         }
-                        .padding(.trailing, 6)
-                        .padding(.bottom, 8)
+                        .padding(.trailing, viewModel.checkUser(key: key) ? 0 : 6)
                     
-                    if viewModel.getUserName() == key {
-                        createButton(title: "손 들기", width: 100, height: 40, size: 16, action: {})
-                            .padding(.bottom, 8)
-
-                    } else {
-                        createButton(title: "콕 찌르기", width: 48, height: 40, size: 12, action: {})
+                    if viewModel.getUserName() != key {
+                        createButton(key: "\(key)-sos", symbol: "sos", width: 27, height: 12, text: "도움요청", action: {})
                             .padding(.trailing, 4)
-                            .padding(.bottom, 8)
-                        createButton(title: "손 든 거에 반응하기", width: 48, height: 40, size: 12, action: {})
-                            .padding(.bottom, 8)
-
+                        createButton(key: "\(key)-heart", symbol: "arrow.up.heart.fill", width: 18, height: 12, text: "도움제안", action: {})
                     }
                 }
+                .padding(.horizontal, 16)
                 
                 if key == viewModel.getUserName() {
                     Divider()
-                        .padding(12)
+                        .padding(.horizontal, 16)
                 }
             }
             .padding(.horizontal, 16)
@@ -84,23 +87,41 @@ struct AppTrackingBoxView: View {
 }
 
 extension AppTrackingBoxView {
-    private func createButton(title: String, width: CGFloat, height: CGFloat, size:CGFloat, action: @escaping () -> Void) -> some View {
-        return VStack {
+    private func createButton(key: String, symbol: String, width: CGFloat, height: CGFloat, text: String, action: @escaping () -> Void) -> some View {
+        return VStack(spacing: 0) {
+            Spacer()
             Button {
+                viewModel.toggleButtonSelection(for: key)
                 action()
+                viewModel.isSelectedButton.toggle()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    viewModel.buttonStates[key] = false
+                }
+                viewModel.isSelectedButton.toggle()
             } label: {
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(.lightGray1)
-                    .stroke(.lightGray2, lineWidth: 0.5)
-                    .frame(width: width, height: height)
-                    .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 0)
+                    .fill(.regularMaterial)
+                    .frame(width: 48, height: 68)
+                    .shadow(color: .black.opacity(0.25), radius: 6, x: 1, y: 1)
                     .overlay {
-                        Text(title)
-                            .font(.system(size: size, weight: .medium))
-                            .lineLimit(0)
+                        VStack(spacing: 0) {
+                            Spacer()
+                            Image(systemName: symbol)
+                                .resizable()
+                                .scaledToFit()
+                                .foregroundStyle(viewModel.isButtonSelected(for: key) ? .accent : .buttonDefault)
+                                .frame(width: width, height: height)
+                                .padding(.bottom, 11)
+                            
+                            Text(text)
+                                .font(.system(size: 8, weight: .medium))
+                                .foregroundStyle(viewModel.isButtonSelected(for: key) ? .accent : .buttonDefault)
+                                .padding(.bottom, 8)
+                        }
                     }
             }
             .buttonStyle(.plain)
+            Spacer()
         }
     }
 }

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
@@ -15,9 +15,10 @@ struct AppTrackingBoxView: View {
             ForEach(viewModel.appTrackings.keys.sorted(by: viewModel.customSort), id: \.self) { key in
                 HStack(spacing: 0) {
                     RoundedRectangle(cornerRadius: 6)
-                        .fill(.regularMaterial)
+                        .fill(.ultraThinMaterial)
+                        .strokeBorder(.buttonStroke, lineWidth: 0.5)
                         .frame(width: viewModel.checkUser(key: key) ? 243 : 140, height: 68)
-                        .shadow(color: .black.opacity(0.25), radius: 6, x: 1, y: 1)
+//                        .shadow(color: .black.opacity(0.25), radius: 6, x: 1, y: 1)
                         .overlay {
                             VStack(spacing: 0) {
                                 HStack(spacing: 0) {
@@ -32,10 +33,8 @@ struct AppTrackingBoxView: View {
                                     Spacer()
                                     
                                     if viewModel.checkUser(key: key) {
-                                        Toggle(isOn: $viewModel.isToggled) {
-                                            Text("")
-                                        }
-                                        .toggleStyle(SwitchToggleStyle(tint: .accent)) // 토글색 안바뀜
+                                        Toggle("", isOn: $viewModel.isToggled)
+                                        .toggleStyle(SwitchToggleStyle(tint: .blue)) // 토글색 안바뀜
                                         .padding(.trailing, 8)
                                         .onChange(of: viewModel.isToggled) { old, new in
                                             if new {
@@ -99,9 +98,9 @@ extension AppTrackingBoxView {
                 viewModel.isSelectedButton.toggle()
             } label: {
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(.regularMaterial)
+                    .fill(.ultraThinMaterial)
                     .frame(width: 48, height: 68)
-                    .shadow(color: .black.opacity(0.25), radius: 6, x: 1, y: 1)
+                    .shadow(color: .black.opacity(0.25), radius: 3, x: 1, y: 1)
                     .overlay {
                         VStack(spacing: 0) {
                             Spacer()

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
@@ -92,7 +92,7 @@ extension AppTrackingBoxView {
                 viewModel.toggleButtonSelection(for: key)
                 action()
                 viewModel.isSelectedButton.toggle()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
                     viewModel.buttonStates[key] = false
                 }
                 viewModel.isSelectedButton.toggle()

--- a/AsyncC/Source/Presentation/MainStatusView/Components/HostView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/HostView.swift
@@ -10,14 +10,14 @@ import SwiftUI
 struct HostTagView: View {
     
     var body: some View {
-        RoundedRectangle(cornerRadius: 3)
-            .fill(.hostBackground)
-            .stroke(.hostStroke, style: .init(lineWidth: 1))
-            .frame(width: 32, height: 12)
+        RoundedRectangle(cornerRadius: 10)
+            .fill(.clear)
+            .stroke(.logOutTextGray, lineWidth: 1)
+            .frame(width: 32, height: 14)
             .overlay {
                 Text("Host")
                     .font(.system(size: 8, weight: .medium))
-                    .foregroundStyle(.lightGray2)
+                    .foregroundStyle(.buttonDefault)
             }
             .padding(.top, 8)
             .padding(.bottom, 4)

--- a/AsyncC/Source/Presentation/MainStatusView/Components/HostView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/HostView.swift
@@ -19,7 +19,5 @@ struct HostTagView: View {
                     .font(.system(size: 8, weight: .medium))
                     .foregroundStyle(.buttonDefault)
             }
-            .padding(.top, 8)
-            .padding(.bottom, 4)
     }
 }

--- a/AsyncC/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
@@ -56,7 +56,7 @@ struct TeamCodeView: View {
                 .buttonStyle(.plain)
             }
             .foregroundStyle(.gray1)
-            .padding(.vertical, 8)
+            .padding(.top, 12)
             .padding(.horizontal, 16)
         }
     }

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
@@ -20,21 +20,22 @@ struct MainStatusView: View {
     
     var body: some View {
         ZStack {
-            Color.lightGray1
-                VStack(spacing: 0){
-                    HStack(spacing: 0) {
-                        TeamCodeView(viewModel: viewModel)
-                        Spacer()
-                    }
-                    
-                    Divider()
-                        .padding(.horizontal, 12)
-                    
-                    HStack(spacing: 0) {
-                        AppTrackingBoxView(viewModel: viewModel)
-                        Spacer()
-                    }
+            RoundedRectangle(cornerRadius: 5)
+                .fill(.regularMaterial)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            
+            VStack(spacing: 0){
+                HStack(spacing: 0) {
+                    TeamCodeView(viewModel: viewModel)
+                    Spacer()
                 }
+                
+                Divider()
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                
+                AppTrackingBoxView(viewModel: viewModel)
+            }
             .frame(width: 270)
             .onAppear {
                 print("App Tracking: \(viewModel.appTrackings)")

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
@@ -26,8 +26,11 @@ class MainStatusViewModel: ObservableObject {
     @Published var hostName: String = ""
     @Published var teamMembers: [String] = []
     @Published var isTeamHost: Bool = false
+    @Published var isToggled: Bool = false
     @Published var isMenuVisible: Bool = false
-
+    @Published var isSelectedButton: Bool = false
+    @Published var buttonStates: [String: Bool] = [:]
+    
     init(teamManagingUseCase: TeamManagingUseCase, appTrackingUseCase: AppTrackingUseCase) {
         self.teamManagingUseCase = teamManagingUseCase
         self.appTrackingUseCase = appTrackingUseCase
@@ -60,6 +63,10 @@ class MainStatusViewModel: ObservableObject {
         }
     }
     
+    func checkUser(key: String) -> Bool {
+        return getUserName() == key
+    }
+    
     func getTeamName() -> String {
         teamManagingUseCase.getTeamName()
     }
@@ -78,6 +85,10 @@ class MainStatusViewModel: ObservableObject {
     
     func leaveTeam() {
         teamManagingUseCase.leaveTeam()
+    }
+    
+    func stopAppTracking() {
+        appTrackingUseCase.stopAppTracking()
     }
     
     func startShowingAppTracking() {
@@ -137,5 +148,13 @@ class MainStatusViewModel: ObservableObject {
         pasteboard.clearContents()
         pasteboard.setString(self.getTeamCode(), forType: .string)
         print("팀 코드 복사")
+    }
+    
+    func isButtonSelected(for key: String) -> Bool {
+        return buttonStates[key] ?? false
+    }
+    
+    func toggleButtonSelection(for key: String) {
+        buttonStates[key] = !(buttonStates[key] ?? false)
     }
 }


### PR DESCRIPTION
## ✅ 작업한 내용
 - 디자인 수정사항 및 UI구현 시 필요한 로직들



## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - macOS regularMaterial을 적용해서 macOS 다른 기본 statusBar 같이 뒤에 실루엣이 살짝 보이고 뒷 배경 색에 영향을 받습니다.
 - 토글은 앱 트래킹을 끄고 키고 하는 토글인데 onChange로 start, stop을 걸었으나 stop이 되지않아 수정해야합니다.
 - 또한 토글 tint 컬러가 변경되지 않습니다. 
 - 패딩 값 놓친거 봐주세요~!

## 📸 스크린샷
<img width="269" alt="스크린샷 2024-11-20 오전 1 33 46" src="https://github.com/user-attachments/assets/f3d5283f-873c-4bc7-8f49-13a8da25a3ef">
<img width="274" alt="스크린샷 2024-11-20 오전 1 34 01" src="https://github.com/user-attachments/assets/34f84801-887c-4413-bbba-fcccd0690dbc">


## 💡 관련 이슈
- Resolved: #
