### PR TITLE
[#70] toggle에 따라 TrackingActive true/false 전환 listener로 팀원에게 상태 공유 후 상태 반영

### DIFF
--- a/AsyncC/Resource/Assets.xcassets/Color/ButtonDefault.colorset/Contents.json
+++ b/AsyncC/Resource/Assets.xcassets/Color/ButtonDefault.colorset/Contents.json
@@ -4,7 +4,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.500",
+          "alpha" : "1.000",
           "blue" : "0x7F",
           "green" : "0x7F",
           "red" : "0x7F"

--- a/AsyncC/Source/Domain/Entity/TrackingActive.swift
+++ b/AsyncC/Source/Domain/Entity/TrackingActive.swift
@@ -1,0 +1,13 @@
+//
+//  TrackingActive.swift
+//  AsyncC
+//
+//  Created by LeeWanJae on 11/25/24.
+//
+
+import Foundation
+
+struct TrackingActive {
+    let userID: String
+    let Active: Bool
+}

--- a/AsyncC/Source/Domain/RepositoryInterfaces/FirebaseRepositoryProtocol.swift
+++ b/AsyncC/Source/Domain/RepositoryInterfaces/FirebaseRepositoryProtocol.swift
@@ -6,6 +6,9 @@
 //
 
 protocol FirebaseRepositoryProtocol {
+    func setTrackingActive(id: String, isActive: Bool)
+    
+    func setUpListenerForTrackingActive(for userID: String, completion: @escaping (Result<Bool, Error>) -> Void)
     
     func setUserAppData(id: String,
                      appName: String,

--- a/AsyncC/Source/Domain/UseCases/TeamManagingUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/TeamManagingUseCase.swift
@@ -67,7 +67,7 @@ final class TeamManagingUseCase {
     }
     
     // MARK: - Listener 생성 및 업데이트
-    private func setUpAllListeners(using teamData: TeamMetaData) {
+    func setUpAllListeners(using teamData: TeamMetaData) {
         let teamInviteCode = teamData.inviteCode
         
         self.firebaseRepository.setUpListenerForTeamData(teamCode: teamInviteCode) { result in
@@ -88,7 +88,7 @@ final class TeamManagingUseCase {
     private func refreshUserAppDataListeners(for updatedMemberIDs: [String]) {
         firebaseRepository.removeListenersForUserAppData()
         appTrackingUseCase.resetAppTrackings()
-        appTrackingUseCase.setupAppTracking(fbRepository: firebaseRepository, teamMemberIDs: updatedMemberIDs)
+        appTrackingUseCase.setupAppTracking(teamMemberIDs: updatedMemberIDs) //  새롭게 업데이트된 멤버 ID를 기반으로 사용자 앱 데이터를 추적하는 리스너를 추가합니다.
     }
     
     func getUserNameConvert(userID: String, handler: @escaping (Result<String, Error>) -> Void) {
@@ -97,6 +97,18 @@ final class TeamManagingUseCase {
         }
     }
     // MARK: - Team 정보 갖고오기
+    
+    func getTeamMetaData(for teamCode: String, handler: @escaping (Result<TeamMetaData, Error>) -> Void) {
+        firebaseRepository.getTeamData(teamCode: teamCode) { result in
+            switch result {
+            case .success(let teamData):
+                handler(.success(teamData))
+            case .failure(let error):
+                handler(.failure(error))
+            }
+        }
+    }
+    
     func getTeamNameAndHostName(for teamInviteCode: String,
                                 handler: @escaping ((Result<(teamName: String, hostName: String), Error>)) -> Void) {
         firebaseRepository.getTeamData(teamCode: teamInviteCode) { result in

--- a/AsyncC/Source/Domain/UseCases/TeamManagingUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/TeamManagingUseCase.swift
@@ -154,7 +154,7 @@ final class TeamManagingUseCase {
     
     func getTeamDetails(
         teamCode: String,
-        handler: @escaping (Result<(teamName: String, hostName: String), Error>) -> Void
+        handler: @escaping (Result<(teamMemberIDs: [String], teamName: String, hostName: String), Error>) -> Void
     ) {
         firebaseRepository.getTeamData(teamCode: teamCode) { [weak self] result in
             switch result {
@@ -162,7 +162,7 @@ final class TeamManagingUseCase {
                 self?.firebaseRepository.getHostName(hostID: teamData.hostID) { hostNameResult in
                     switch hostNameResult {
                     case .success(let hostName):
-                        handler(.success((teamName: teamData.teamName, hostName: hostName)))
+                        handler(.success((teamMemberIDs:teamData.memberIDs, teamName: teamData.teamName, hostName: hostName)))
                     case .failure(let error):
                         handler(.failure(error))
                     }

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxContentView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxContentView.swift
@@ -5,23 +5,61 @@
 //  Created by LeeWanJae on 11/22/24.
 //
 
+//import SwiftUI
+//
+//struct AppIconBoxContentView: View {
+//    @ObservedObject var viewModel: MainStatusViewModel
+//    var key: String
+//    
+//    var body: some View {
+//        HStack(spacing: 4) {
+//            
+//            ForEach(viewModel.appTrackings[key] ?? [], id:\.self) { appName in
+//                Image("\(appName)")
+//                    .resizable()
+//                    .scaledToFit()
+//                    .frame(width: 36, height: 36)
+//                    .opacity(viewModel.getOpacity(appName: appName, apps: viewModel.appTrackings[key] ?? []))
+//            }
+//        }
+//        .padding(.leading, 12)
+//        .frame(maxWidth: .infinity, alignment: .leading)
+//    }
+//}
+
 import SwiftUI
 
 struct AppIconBoxContentView: View {
     @ObservedObject var viewModel: MainStatusViewModel
     var key: String
-    
+
     var body: some View {
         HStack(spacing: 4) {
-            ForEach(viewModel.appTrackings[key] ?? [], id:\.self) { appName in
-                Image("\(appName)")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 36, height: 36)
-                    .opacity(viewModel.getOpacity(appName: appName, apps: viewModel.appTrackings[key] ?? []))
+            if let userID = viewModel.nameToUserId[key] {
+                if viewModel.trackingActive[userID] ?? true || viewModel.checkUser(key: key) {
+                    ForEach(viewModel.appTrackings[key] ?? [], id: \.self) { appName in
+                        Image("\(appName)")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 36, height: 36)
+                            .opacity(viewModel.getOpacity(appName: appName, apps: viewModel.appTrackings[key] ?? []))
+                    }
+                } else {
+                    HStack() {
+                        Spacer()
+                        VStack {
+                            Spacer()
+                            Text("비활성화됨")
+                                .font(.system(size: 16, weight: .medium))
+                                .foregroundColor(.buttonDefault.opacity(0.5))
+                            Spacer()
+                        }
+                        Spacer()
+                    }
+                }
             }
         }
-        .padding(.leading, 12)
+        .padding(.horizontal, 12)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxContentView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxContentView.swift
@@ -5,28 +5,6 @@
 //  Created by LeeWanJae on 11/22/24.
 //
 
-//import SwiftUI
-//
-//struct AppIconBoxContentView: View {
-//    @ObservedObject var viewModel: MainStatusViewModel
-//    var key: String
-//    
-//    var body: some View {
-//        HStack(spacing: 4) {
-//            
-//            ForEach(viewModel.appTrackings[key] ?? [], id:\.self) { appName in
-//                Image("\(appName)")
-//                    .resizable()
-//                    .scaledToFit()
-//                    .frame(width: 36, height: 36)
-//                    .opacity(viewModel.getOpacity(appName: appName, apps: viewModel.appTrackings[key] ?? []))
-//            }
-//        }
-//        .padding(.leading, 12)
-//        .frame(maxWidth: .infinity, alignment: .leading)
-//    }
-//}
-
 import SwiftUI
 
 struct AppIconBoxContentView: View {

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxHeaderView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxHeaderView.swift
@@ -39,7 +39,12 @@ struct AppIconBoxHeaderView: View {
                             viewModel.startShowingAppTracking()
                             viewModel.startAppTracking()
                             viewModel.setUpAllListener()
+                            
                             print("Start tracking")
+                        }
+                        
+                        DispatchQueue.main.async {
+                            viewModel.objectWillChange.send()
                         }
                     }
             }

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxHeaderView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxHeaderView.swift
@@ -26,8 +26,18 @@ struct AppIconBoxHeaderView: View {
             
             Spacer()
             
-            if viewModel.checkUser(key: key) {
-                Toggle("", isOn: $viewModel.isToggled)
+            if let userID = viewModel.nameToUserId[key] {
+                if key == viewModel.getUserName() {
+                    Toggle("", isOn: Binding(
+                        get: { viewModel.trackingActive[userID] ?? true },
+                        set: { newValue in
+                            viewModel.updateUserTrackingStatus(userID: userID, isActive: newValue)
+                            
+                            if viewModel.checkUser(key: key) {
+                                viewModel.isToggled = newValue
+                            }
+                        }
+                    ))
                     .toggleStyle(SwitchToggleStyle(tint: .blue))
                     .padding(.trailing, 8)
                     .onChange(of: viewModel.isToggled) { old, new in
@@ -42,11 +52,8 @@ struct AppIconBoxHeaderView: View {
                             
                             print("Start tracking")
                         }
-                        
-                        DispatchQueue.main.async {
-                            viewModel.objectWillChange.send()
-                        }
                     }
+                }
             }
         }
         .padding(.top, 8)

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxHeaderView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxHeaderView.swift
@@ -32,11 +32,14 @@ struct AppIconBoxHeaderView: View {
                     .padding(.trailing, 8)
                     .onChange(of: viewModel.isToggled) { old, new in
                         if old {
-                            viewModel.startShowingAppTracking()
-                            print("Started tracking")
-                        } else {
                             viewModel.stopAppTracking()
-                            print("S")
+                            viewModel.stopOtherUserAppTracking()
+                            print("Stop tracking")
+                        } else {
+                            viewModel.startShowingAppTracking()
+                            viewModel.startAppTracking()
+                            viewModel.setUpAllListener()
+                            print("Start tracking")
                         }
                     }
             }

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
@@ -11,40 +11,70 @@ struct AppTrackingBoxView: View {
     @ObservedObject var viewModel: MainStatusViewModel
     
     var body: some View {
-        VStack(spacing: 0) {
-            ForEach(viewModel.appTrackings.keys.sorted(by: viewModel.customSort), id: \.self) { (key: String) in
-                if let trackingData = viewModel.appTrackings[key], !trackingData.isEmpty {
+        ToggleAppTrackingBoxView()
+    }
+}
+
+extension AppTrackingBoxView {
+    @ViewBuilder
+    func ToggleAppTrackingBoxView() -> some View {
+        if viewModel.isToggled {
+            VStack(spacing: 0) {
+                ForEach(viewModel.appTrackings.keys.sorted(by: viewModel.customSort), id: \.self) { (key: String) in
+                        HStack(spacing: 0) {
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(.ultraThinMaterial)
+                                .strokeBorder(.buttonStroke, lineWidth: 0.5)
+                                .frame(width: viewModel.checkUser(key: key) ? 243 : 140, height: 68)
+                                .overlay {
+                                    VStack(spacing: 0) {
+                                        AppIconBoxHeaderView(viewModel: viewModel, key: key)
+                                        AppIconBoxContentView(viewModel: viewModel, key: key)
+                                    }
+                                }
+                                .padding(.trailing, 4)
+                            
+                            if viewModel.getUserName() != key {
+                                SyncButton(viewModel: viewModel, key: key, action: {})
+                            }
+                        }
+                        .padding(.vertical, 4.5)
+                        .padding(.horizontal, 16)
+                        
+                        if key == viewModel.getUserName() {
+                            Rectangle()
+                                .fill(.clear)
+                                .frame(height: 1)
+                                .overlay {
+                                    Divider()
+                                }
+                                .padding(.vertical, 12)
+                        }
+                }
+                .padding(.horizontal, 16)
+                Spacer()
+            }
+        } else {
+            VStack(spacing: 0) {
+                if viewModel.appTrackings[viewModel.getUserName()] != nil {
                     HStack(spacing: 0) {
                         RoundedRectangle(cornerRadius: 6)
                             .fill(.ultraThinMaterial)
                             .strokeBorder(.buttonStroke, lineWidth: 0.5)
-                            .frame(width: viewModel.checkUser(key: key) ? 243 : 140, height: 68)
+                            .frame(width:243, height: 68)
                             .overlay {
                                 VStack(spacing: 0) {
-                                    AppIconBoxHeaderView(viewModel: viewModel, key: key)
-                                    AppIconBoxContentView(viewModel: viewModel, key: key)
+                                    AppIconBoxHeaderView(viewModel: viewModel, key: viewModel.getUserName())
+                                    AppIconBoxContentView(viewModel: viewModel, key: viewModel.getUserName())
                                 }
                             }
                             .padding(.trailing, 4)
-                        
-                        if viewModel.getUserName() != key {
-                            SyncButton(viewModel: viewModel, key: key, action: {})
-                        }
                     }
                     .padding(.vertical, 4.5)
                     .padding(.horizontal, 16)
                 }
-                
-                if key == viewModel.getUserName() {
-                    Rectangle()
-                        .overlay {
-                            Divider()
-                        }
-                        .padding(.vertical, 12)
-                }
+                Spacer()
             }
-            .padding(.horizontal, 16)
-            Spacer()
         }
     }
 }

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
@@ -13,25 +13,27 @@ struct AppTrackingBoxView: View {
     var body: some View {
         VStack(spacing: 0) {
             ForEach(viewModel.appTrackings.keys.sorted(by: viewModel.customSort), id: \.self) { (key: String) in
-                HStack(spacing: 0) {
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(.ultraThinMaterial)
-                        .strokeBorder(.buttonStroke, lineWidth: 0.5)
-                        .frame(width: viewModel.checkUser(key: key) ? 243 : 140, height: 68)
-                        .overlay {
-                            VStack(spacing: 0) {
-                                AppIconBoxHeaderView(viewModel: viewModel, key: key)
-                                AppIconBoxContentView(viewModel: viewModel, key: key)
+                if let trackingData = viewModel.appTrackings[key], !trackingData.isEmpty {
+                    HStack(spacing: 0) {
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(.ultraThinMaterial)
+                            .strokeBorder(.buttonStroke, lineWidth: 0.5)
+                            .frame(width: viewModel.checkUser(key: key) ? 243 : 140, height: 68)
+                            .overlay {
+                                VStack(spacing: 0) {
+                                    AppIconBoxHeaderView(viewModel: viewModel, key: key)
+                                    AppIconBoxContentView(viewModel: viewModel, key: key)
+                                }
                             }
+                            .padding(.trailing, 4)
+                        
+                        if viewModel.getUserName() != key {
+                            SyncButton(viewModel: viewModel, key: key, action: {})
                         }
-                        .padding(.trailing, 4)
-                    
-                    if viewModel.getUserName() != key {
-                        SyncButton(viewModel: viewModel, key: key, action: {})
                     }
+                    .padding(.vertical, 4.5)
+                    .padding(.horizontal, 16)
                 }
-                .padding(.vertical, 4.5)
-                .padding(.horizontal, 16)
                 
                 if key == viewModel.getUserName() {
                     Rectangle()

--- a/AsyncC/Source/Presentation/MainStatusView/Components/SyncButton.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/SyncButton.swift
@@ -33,17 +33,29 @@ struct SyncButton: View {
                             Image(systemName: "arrow.2.squarepath")
                                 .resizable()
                                 .scaledToFit()
-                                .foregroundStyle(viewModel.isButtonSelected(for: key) ? .accent : .buttonDefault)
+                                .foregroundStyle(viewModel.isButtonSelected(for: key) ? .accent : .buttonDefault.opacity(isButtonDisabled() ? 0.3 : 0.5))
                                 .frame(width: 30, height: 12)
                             
                             Text("Sync On")
                                 .font(.system(size: 10, weight: .bold))
-                                .foregroundStyle(viewModel.isButtonSelected(for: key) ? .accent : .buttonDefault)
+                                .foregroundStyle(viewModel.isButtonSelected(for: key) ? .accent : .buttonDefault.opacity(isButtonDisabled() ? 0.3 : 0.5))
                                 .padding(.bottom, 12)
                         }
                     }
             }
             .buttonStyle(.plain)
+            .disabled(isButtonDisabled())
+        }
+    }
+}
+
+extension SyncButton {
+    func isButtonDisabled() -> Bool {
+        if let userID = viewModel.nameToUserId[key] {
+            let isActive = viewModel.trackingActive[userID] ?? true // 기본값은 true
+            return !isActive // active가 false일 때 버튼을 비활성화
+        } else {
+            return true // userID를 찾을 수 없으면 버튼을 비활성화
         }
     }
 }

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
@@ -16,6 +16,7 @@ struct MainStatusView: View {
         ZStack {
             RoundedRectangle(cornerRadius: 5)
                 .fill(.regularMaterial)
+                .frame(maxWidth: 270)
 
             VStack(spacing: 0){
                 HStack(spacing: 0) {
@@ -36,6 +37,7 @@ struct MainStatusView: View {
                 viewModel.setUpAllListener()
             }
         }
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
@@ -31,9 +31,9 @@ struct MainStatusView: View {
             }
             .frame(width: 270)
             .onAppear {
-                print("App Tracking: \(viewModel.appTrackings)")
                 viewModel.getTeamData(teamCode: viewModel.getTeamCode())
                 viewModel.startShowingAppTracking()
+                viewModel.setUpAllListener()
             }
         }
     }

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
@@ -24,6 +24,7 @@ class MainStatusViewModel: ObservableObject {
     @Published var appTrackings: [String: [String]] = [:] {
         didSet {
             print("viewModel.appTrackings: \(appTrackings)")
+            objectWillChange.send()
         }
     }
     @Published var teamName: String = ""
@@ -133,12 +134,6 @@ class MainStatusViewModel: ObservableObject {
         appTrackingUseCase.startAppTracking()
     }
     
-    func removeUserFromTracking(userID: String) {
-        DispatchQueue.main.async {
-            self.appTrackings[userID] = nil
-        }
-    }
-    
     func setUpAllListener() {
         let teamCode = self.getTeamCode()
         
@@ -189,5 +184,10 @@ class MainStatusViewModel: ObservableObject {
     
     func toggleButtonSelection(for key: String) {
         buttonStates[key] = !(buttonStates[key] ?? false)
+    }
+    
+    func myDataChanged() {
+        appTrackings.removeAll()
+        appTrackings[self.getUserName()] = []
     }
 }


### PR DESCRIPTION
## ✅ 작업한 내용
 - 토글에 따른 프로그램 추적 실행 로직 구현 및 본인 앱 추적 리스너 중복 수정 + 다른 사람 방 나감 추적 수정
 - toggle에 따라 TrackingActive true/false 전환 listener로 팀원에게 상태 공유 후 상태 반영
 - 모델 추가
-  [x]  Firebase로 현재 내 상태 공유로직
- [x]  토글 왔다 갔다하면 내 프로그램 트래킹되는 거 단일만 표출
- [x]  내 프로그램 추적 안꺼지는 버그
- [x]  다른 사람 앱 추적 막기
- [x]  다른 사람 앱 추적 다시 실행
- [x]  토글 off 상태에서 상대방 들어오고 나가는거 추적
- [x]  토글 off에서 on으로 전환 시 내 프로그램 3개씩 추적
- [x]  Toggle on, off에 따라 UI 줄어들고 움직이기
- [x]  방에 들어와있는 사람 나가면 검은색 화면으로 남음

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - userAppData에 유저마다 활성 비활성화 상태 Bool 값: 토글로 값 변경
 - 방에 입장한 유저 수에 맞게 동적으로 UI변화 및 검은색으로 나간사람 남던 자리 수정



## 📸 스크린샷
<img width="281" alt="스크린샷 2024-11-25 오후 12 17 07" src="https://github.com/user-attachments/assets/7db30e0e-383d-4bd6-bb4c-4d19111334af">

<img width="267" alt="스크린샷 2024-11-25 오후 12 12 07" src="https://github.com/user-attachments/assets/67bf042b-6696-46e4-88f4-8bd795038d4f">
<br/>
<img width="1153" alt="스크린샷 2024-11-25 오후 12 12 44" src="https://github.com/user-attachments/assets/50bd6fe3-42e9-482b-888d-a9c6f0d278ff">
<br/>
userAppData에 유저마다 활성 비활성화 상태 Bool 값: 토글로 값 변경
<br/>
<img width="277" alt="스크린샷 2024-11-25 오후 12 14 07" src="https://github.com/user-attachments/assets/e36a6b1a-1a41-4214-a0b1-eabfb5c8ad82">
<br/>
방에 입장한 유저 수에 맞게 동적으로 UI변화 및 검은색으로 나간사람 남던 자리 수정

## 💡 관련 이슈
- Resolved: #
