### PR TITLE
Fix/#88 - sync와 관련된 window가 계속 잘못된 타이밍에 나오는 bug 잡기

### DIFF
--- a/AsyncC/App/AsyncCApp.swift
+++ b/AsyncC/App/AsyncCApp.swift
@@ -23,7 +23,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Firebase configure
         FirebaseApp.configure()
         setUpContentViewWindow()
-        setUpStatusBarItem()
         router.appDelegate = self
     }
 }

--- a/AsyncC/App/AsyncCApp.swift
+++ b/AsyncC/App/AsyncCApp.swift
@@ -24,7 +24,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         FirebaseApp.configure()
         setUpContentViewWindow()
         setUpStatusBarItem()
-        setUpHUDWindow()
         router.appDelegate = self
     }
 }

--- a/AsyncC/Source/Domain/UseCases/SyncUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/SyncUseCase.swift
@@ -37,6 +37,10 @@ final class SyncUseCase {
     
     func setUpListenerForEmoticons(userID: String) {
         firebaseRepository.setupListenerForSyncRequest(userID: userID) { result in
+            if self.router?.isFirstTimeSetUp() == true {
+                self.router?.finishFirstSetUp()
+                return
+            }
             switch result {
             case .success(let syncRequest):
                 DispatchQueue.main.async {

--- a/AsyncC/Source/Presentation/Flow/Router.swift
+++ b/AsyncC/Source/Presentation/Flow/Router.swift
@@ -20,6 +20,8 @@ class Router: ObservableObject{
     var appTrackingUseCase: AppTrackingUseCase
     var teamManagingUseCase: TeamManagingUseCase
     var syncUseCase: SyncUseCase
+    
+    private var firstSetUp: Bool = true
 
     
     init() {
@@ -113,6 +115,14 @@ class Router: ObservableObject{
         if let delegate = appDelegate {
             delegate.setUpContentViewWindow()
         }
+    }
+    
+    func isFirstTimeSetUp() -> Bool {
+        return firstSetUp
+    }
+    
+    func finishFirstSetUp() {
+        firstSetUp = false
     }
     
     // MARK: - PendingSyncRequestView


### PR DESCRIPTION
## ✅ 작업한 내용
 - pendingStatusView가 앱 처음 실행했을때 뜨는 bug 잡음
 - pendingStatusView가 mainStatusView 처음 뜰때 같이 뜨는 bug 잡음

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - 처음 앱이 실행되고, listener를 붙이는 과정에서 sync request listener 안에있는 코드가 한번 실행됩니다... 그래서 처음 앱실행했을때 sync request를 받지 않았지만 pendingSyncRequestView가 뜨고요. 
 - 해결 방안은 처음 실행되는 지점을 파악해서 Bool로 관리하고, 처음 setup에는 view가 뜨는 코드를 건너뜁니다.

## 💡 관련 이슈
- Resolved: #88
