### PR TITLE
[#95] - JoinTeamView 버튼 밑에 padding이 다른 뷰와 불일치한거 고치기

### DIFF
--- a/AsyncC/Source/Presentation/JoinTeamView/JoinTeamView.swift
+++ b/AsyncC/Source/Presentation/JoinTeamView/JoinTeamView.swift
@@ -17,6 +17,7 @@ struct JoinTeamView: View {
     
     var body: some View {
         VStack(spacing: 16) {
+            Spacer()
             Text("팀 참여하기")
                 .font(Font.system(size: 16, weight: .semibold))
             ZStack {
@@ -51,8 +52,13 @@ struct JoinTeamView: View {
                     Spacer()
                 }
                 .padding(EdgeInsets(top: 0, leading: 15, bottom: 0, trailing: 0))
+                .frame(height: 3)
+            } else {
+                Spacer()
+                    .frame(height: 3)
             }
             Spacer()
+                .frame(height: 4)
             HStack {
                 Spacer()
                 Button("취소") {
@@ -76,7 +82,7 @@ struct JoinTeamView: View {
                 .customButtonStyle(backgroundColor: .systemBlue, foregroundColor: .white)
                 .disabled(teamCode.isEmpty)
             }
-            .padding(EdgeInsets(top: 0, leading: 0, bottom: 16, trailing: 0))
+            .padding(EdgeInsets(top: 0, leading: 0, bottom: 20, trailing: 0))
         }
         .padding(EdgeInsets(top: 50, leading: 12, bottom: 16, trailing: 12))
         .frame(width: 270, height: 200)


### PR DESCRIPTION
## ✅ 작업한 내용
 - JoinTeamView 버튼 밑에 padding이 다른 뷰와 불일치한거 고치기

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - 에러문구가 없을때 비슷한 높이의 spacer를 넣어서, 에러 있을때 없을때 버튼 위치 동일하게 하기
 - Spacer를 활용해서 버튼 위치 다른 뷰와 균일하게 갖고가기

## 💡 관련 이슈
- Resolved: #95
