### PR TITLE
[#57] JoinTeamView에서 팀이 존재하는데 팀이 없다는 에러가 잘못 뜨는상황 고침

### DIFF
--- a/AsyncC/Source/Data/Repositories/FirebaseRepository.swift
+++ b/AsyncC/Source/Data/Repositories/FirebaseRepository.swift
@@ -412,9 +412,9 @@ final class FirebaseRepository: FirebaseRepositoryProtocol
                                              hostID: data["hostID"] as? String ?? "",
                                              isDisband: data["isDisband"] as? String ?? "")
                 handler(.success(teamData))
-                return
+            } else {
+                handler(.failure(FirebaseError(errorMessage: "No team data found")))
             }
-            handler(.failure(FirebaseError(errorMessage: "No team data found")))
         }
     }
     
@@ -448,10 +448,10 @@ final class FirebaseRepository: FirebaseRepositoryProtocol
                 let hostName = data["name"] as? String ?? ""
                 print("data: \(hostName)")
                 handler(.success(hostName))
-                return
+            } else {
+                handler(.failure(FirebaseError(errorMessage: "No host found")))
             }
         }
-        handler(.failure(FirebaseError(errorMessage: "No host found")))
     }
     
     func removeUser(userID: String, teamCode: String) {


### PR DESCRIPTION
## ✅ 작업한 내용
 - JoinTeamView에서 팀이 존재하는데 팀이 없다는 에러가 잘못 뜨는상황 고침

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - teamCode를 사용해서 teamData를 갖고오고, teamData안에서 hostID를 사용해서 hostName을 갖고오는 firebase fetch function에서 if 문에서 document가 없으면 error를 띄어야되는데, 바보이슈로 document가 있으면 return하고 그 밑에 error를 handle 함. 이렇게 하면 안되는 이유가 document를 확인하는 부분에 (closure) 시간이 걸려서 코드 그냥 바로 error handling해버림
 - else에다 넣어서 해결 ㅎ 아무튼 레슨 런
틀린 코드 예시: (else 하고 그 failure handling을 했어야함)
```
 func getTeamData(teamCode: String, handler: @escaping ((Result<TeamMetaData, Error>) -> Void)){
        let db = Firestore.firestore()
        let docRef = db.collection("teamMetaData").document(teamCode)
        
        docRef.getDocument { (document, error) in
            if let document, document.exists {
                guard let data = document.data() else {return}
                let teamData  = TeamMetaData(memberIDs: data["memberIDs"] as? [String] ?? [],
                                             teamName: data["teamName"] as? String ?? "",
                                             inviteCode: data["inviteCode"] as? String ?? "",
                                             hostID: data["hostID"] as? String ?? "",
                                             isDisband: data["isDisband"] as? String ?? "")
                handler(.success(teamData))
                return
            }
            handler(.failure(FirebaseError(errorMessage: "No team data found")))
        }
    }
```

## 💡 관련 이슈
- Resolved: #57 
