### PR TITLE
[#100] - 회원 탈퇴 UI 구현

### DIFF
--- a/AsyncC.xcodeproj/project.pbxproj
+++ b/AsyncC.xcodeproj/project.pbxproj
@@ -427,6 +427,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -458,6 +459,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/AsyncC/App/AsyncCApp.swift
+++ b/AsyncC/App/AsyncCApp.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import FirebaseCore
 
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var launchWindowController: NSWindowController?
     var statusBarItem: NSStatusItem?
     var hudWindow: NSPanel?
@@ -18,6 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var contentViewWindow: NSWindow?
     let router = Router()
     var exitConfirmation: NSPanel?
+    var accountDeactivation: NSPanel?
     
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Firebase configure

--- a/AsyncC/Source/Extension/Extension + AccountDeactivation.swift
+++ b/AsyncC/Source/Extension/Extension + AccountDeactivation.swift
@@ -1,0 +1,60 @@
+//
+//  Extension + ExitConfirmation.swift
+//  AsyncC
+//
+//  Created by Jin Lee on 11/21/24.
+//
+
+import AppKit
+import SwiftUI
+
+extension AppDelegate {
+    func makeAccountDeactivation() {
+        accountDeactivation = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 140, height: 50),
+            styleMask: [.nonactivatingPanel],
+            backing: .buffered, defer: false
+        )
+    }
+    
+    func setUpAccountDeactivation() {
+        makeAccountDeactivation()
+        
+        // Remove the default background color of NSPanel
+        accountDeactivation?.isOpaque = false
+        accountDeactivation?.backgroundColor = .clear
+        
+        accountDeactivation?.isMovable = false
+        accountDeactivation?.collectionBehavior = [.stationary, .fullScreenAuxiliary]
+        accountDeactivation?.level = .floating
+        accountDeactivation?.contentViewController = NSHostingController(rootView: AccountDeactivation().environmentObject(self.router))
+        
+        // Set the CornerRadius for the View inside the NSPanel
+        accountDeactivation?.contentView?.wantsLayer = true
+        accountDeactivation?.contentView?.layer?.cornerRadius = 4.0
+        accountDeactivation?.contentView?.layer?.masksToBounds = true
+        
+        accountDeactivation?.appearance = NSAppearance(named: .aqua)
+    }
+    
+    func showAccountDeactivation() {
+        if let accountDeactivation = self.accountDeactivation, let contentViewWindow = self.contentViewWindow {
+            if accountDeactivation.isVisible {
+                accountDeactivation.orderOut(nil)
+            } else {
+                let xPosition = contentViewWindow.frame.origin.x + 240
+                let yPosition = contentViewWindow.frame.origin.y + 115
+                
+                accountDeactivation.setFrameOrigin(NSPoint(x: xPosition, y: yPosition))
+                accountDeactivation.makeKeyAndOrderFront(nil)
+            }
+        }
+    }
+    
+    func closeAccountDeactivation() {
+        if let accountDeactivation = self.accountDeactivation {
+            accountDeactivation.close()
+            self.accountDeactivation = nil
+        }
+    }
+}

--- a/AsyncC/Source/Extension/Extension + ContentViewWindow.swift
+++ b/AsyncC/Source/Extension/Extension + ContentViewWindow.swift
@@ -17,6 +17,8 @@ extension AppDelegate {
             backing: .buffered,
             defer: false
         )
+        
+        contentViewWindow?.delegate = self
     }
     
     func setUpContentViewWindow() {
@@ -29,5 +31,12 @@ extension AppDelegate {
         contentViewWindow?.isReleasedWhenClosed = false
         contentViewWindow?.contentView = NSHostingView(rootView: ContentView().environmentObject(self.router))
         contentViewWindow?.makeKeyAndOrderFront(nil)
+    }
+    
+    func windowWillClose(_ notification: Notification) {
+        if let accountDeactivation = self.accountDeactivation {
+            accountDeactivation.close()
+            self.accountDeactivation = nil
+        }
     }
 }

--- a/AsyncC/Source/Presentation/CreateOrJoinTeam/AccountDeactivation.swift
+++ b/AsyncC/Source/Presentation/CreateOrJoinTeam/AccountDeactivation.swift
@@ -1,0 +1,43 @@
+//
+//  AccountDeactivation.swift
+//  AsyncC
+//
+//  Created by Jin Lee on 11/26/24.
+//
+
+import SwiftUI
+
+struct AccountDeactivation: View {
+    @EnvironmentObject var router: Router
+    
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(.regularMaterial)         
+            VStack(alignment: .leading) {
+                Button {
+                    router.push(view: .LogoutView)
+                    router.closeAccountDeactivation()
+                } label: {
+                    Text("로그아웃")
+                }
+                .buttonStyle(.plain)
+                Divider()
+                    .foregroundStyle(.lightGray2)
+                Button {
+                    router.push(view: .AccountDeleteView)
+                    router.closeAccountDeactivation()
+                } label: {
+                    Text("회원 탈퇴")
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 10)
+            .font(.system(size: 10, weight: .regular))
+            .foregroundStyle(.darkGray2)
+        }
+        .frame(width: 140, height: 50)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+}

--- a/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamView.swift
+++ b/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamView.swift
@@ -22,12 +22,27 @@ struct CreateOrJoinTeamView: View {
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundStyle(.darkGray2)
                 Spacer()
-                Text("로그아웃")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.logOutTextGray)
-                    .onTapGesture {
-                        router.push(view: .LogoutView)
+//                Text("로그아웃")
+//                    .font(.system(size: 10, weight: .medium))
+//                    .foregroundStyle(.logOutTextGray)
+//                    .onTapGesture {
+//                        router.push(view: .LogoutView)
+//                    }
+                Button {
+                    if ((router.accountDeactivation()?.isVisible) != nil) {
+                        router.closeAccountDeactivation()
+                    } else {
+                        router.setUpAccountDeactivation()
+                        router.showAccountDeactivation()
                     }
+                } label: {
+                    Image(systemName: "chevron.right")
+                        .resizable()
+                        .scaledToFit()
+                        .foregroundStyle(.gray1)
+                        .frame(height: 16)
+                }
+                .buttonStyle(.plain)
             }
             .padding(.horizontal, 8)
             Divider()

--- a/AsyncC/Source/Presentation/Flow/Router.swift
+++ b/AsyncC/Source/Presentation/Flow/Router.swift
@@ -40,6 +40,7 @@ class Router: ObservableObject{
         case LoginView
         case CheckToJoinTeamView(teamCode: String, teamName: String, hostName: String)
         case LogoutView
+        case AccountDeleteView
     }
     
     @ViewBuilder func view(for route: AsyncCViews) -> some View {
@@ -64,6 +65,8 @@ class Router: ObservableObject{
                                 teamCode: teamCode,
                                 teamName: teamName,
                                 hostName: hostName)
+        case .AccountDeleteView:
+            AccountDeleteView()
         }
     }
     
@@ -202,6 +205,31 @@ class Router: ObservableObject{
     func contentViewWindow() -> NSWindow? {
         if let delegate = appDelegate {
             return delegate.contentViewWindow
+        }
+        return nil
+    }
+
+    func setUpAccountDeactivation() {
+        if let delegate = appDelegate {
+            delegate.setUpAccountDeactivation()
+        }
+    }
+    
+    func showAccountDeactivation() {
+        if let delegate = appDelegate {
+            delegate.showAccountDeactivation()
+        }
+    }
+    
+    func closeAccountDeactivation() {
+        if let delegate = appDelegate {
+            delegate.closeAccountDeactivation()
+        }
+    }
+    
+    func accountDeactivation() -> NSPanel? {
+        if let delegate = appDelegate {
+            return delegate.accountDeactivation
         }
         return nil
     }

--- a/AsyncC/Source/Presentation/Login/AccountDeleteView.swift
+++ b/AsyncC/Source/Presentation/Login/AccountDeleteView.swift
@@ -1,0 +1,47 @@
+//
+//  LogoutView.swift
+//  AsyncC
+//
+//  Created by Jin Lee on 11/18/24.
+//
+
+import SwiftUI
+
+struct AccountDeleteView: View {
+    @EnvironmentObject var router: Router
+    
+    var body: some View {
+        VStack {
+            Text("SyncC")
+                .font(.system(size: 16, weight: .semibold))
+            Text("회원 탈퇴를 계속 진행하면\n더이상 AsyncC 를 사용할 수 없습니다")
+                .multilineTextAlignment(.center)
+                .font(.system(size: 12, weight: .regular))
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 13)
+            Spacer()
+            HStack {
+                Spacer()
+                HStack() {
+                    Button {
+                        router.pop()
+                    } label: {
+                        Text("취소")
+                    }
+                    .customButtonStyle(backgroundColor: .white, foregroundColor: .darkGray2)
+                    Button {
+                        // MARK: - 회원 탈퇴 로직
+
+                        router.push(view: .LoginView)
+                    } label: {
+                        Text("회원탈퇴")
+                            .foregroundStyle(.red)
+                    }
+                    .customButtonStyle(backgroundColor: .white, foregroundColor: .systemRed)
+                }
+            }
+        }
+        .padding(EdgeInsets(top: 50, leading: 12, bottom: 16, trailing: 12))
+        .frame(width: 270, height: 200)
+    }
+}


### PR DESCRIPTION
## ✅ 작업한 내용
 - 로그아웃&회원탈퇴 팝업 구현
-  회원탈퇴 뷰 구현
- ContentViewWindow가 닫힐때 로그아웃&회원탈퇴 팝업도 닫히게 구현
## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - AppDelegate에 `NSWindowDelegate`를 추가하여 ContentViewWindow가 닫힐때 로그아웃&회원탈퇴 팝업이 열려있다면 닫히게 구현

## 📸 스크린샷
<img width="406" alt="스크린샷 2024-11-26 오후 8 48 38" src="https://github.com/user-attachments/assets/f76198dc-d89b-44f1-9c35-a29c6c554dc8">
<img width="338" alt="스크린샷 2024-11-26 오후 8 48 54" src="https://github.com/user-attachments/assets/651b828b-5567-40b0-9fbe-2847a48c0374">


## 💡 관련 이슈
- Resolved: #100 
