### PR TITLE
[#99] - sync 요청을 여러번 눌렀을때 request가 여러번 오고 창이 안닫치는 버그 해결

### DIFF
--- a/AsyncC/Source/Domain/RepositoryInterfaces/FirebaseRepositoryProtocol.swift
+++ b/AsyncC/Source/Domain/RepositoryInterfaces/FirebaseRepositoryProtocol.swift
@@ -52,6 +52,8 @@ protocol FirebaseRepositoryProtocol {
     
     func checkExistUserBy(userID: String, completion: @escaping (Bool, String?) -> Void)
     
+    func getSyncRequestOf(user userID: String, handler: @escaping ((Result<SyncRequest, Error>) -> Void))
+    
     func sendSyncRequest(senderID: String, senderName: String, syncRequestType: String, receiver: String, timestamp: Date, isAcknowledged: Bool) 
     
     func setupListenerForSyncRequest(userID: String, handler: @escaping (Result<SyncRequest, Error>) -> Void)


### PR DESCRIPTION
## ✅ 작업한 내용
 - sync 요청을 여러번 눌렀을때 request가 여러번 오고 창이 안닫치는 버그 해결

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - sync 요청을 firestore로 보내기 전에, 일단 받는이의 정보를 갖고와서, 이전 request나 action이 언제였는지 확인. 최소 10초 지나야, 요청이 firestore로 전송이 됨

## 💡 관련 이슈
- Resolved: #99
