### PR TITLE
[#115] 애플 토큰 삭제: 애플 로그인 삭제 구현

### DIFF
--- a/AsyncC/Source/Extension/Extension + Date.swift
+++ b/AsyncC/Source/Extension/Extension + Date.swift
@@ -1,0 +1,17 @@
+//
+//  Extension + Date.swift
+//  AsyncC
+//
+//  Created by LeeWanJae on 11/27/24.
+//
+
+import Foundation
+
+extension Date {
+    func isWithinPast(minutes: Int) -> Bool {
+        let now = Date.now
+        let timeAgo = Date.now.addingTimeInterval(-1 * TimeInterval(60 * minutes))
+        let range = timeAgo...now
+        return range.contains(self)
+    }
+}

--- a/AsyncC/Source/Presentation/Login/AccountDeleteView.swift
+++ b/AsyncC/Source/Presentation/Login/AccountDeleteView.swift
@@ -32,8 +32,10 @@ struct AccountDeleteView: View {
                     .customButtonStyle(backgroundColor: .white, foregroundColor: .darkGray2)
                     Button {
                         // MARK: - 회원 탈퇴 로직
-                        viewModel.accountManagingUseCase.deleteFirebaseAuthUser()
-                        router.push(view: .LoginView)
+                        Task {
+                            await viewModel.accountManagingUseCase.deleteFirebaseAuthUser()
+                            router.push(view: .LoginView)
+                        }
                     } label: {
                         Text("회원탈퇴")
                             .foregroundStyle(.red)


### PR DESCRIPTION
## ✅ 작업한 내용
 - 애플 토큰 삭제: 애플 로그인 삭제 구현

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - 애플 토큰 삭제: 애플 로그인 삭제 구현
 - 파이어베이스 공식 영상과 문서를 바탕으로 구현했습니다.
 - 파이어베이스 공식 영상에서 애플 토큰 권한 삭제 구현 시 바로 직전에 사용자 로그인이 필수로 들어가야한다고 안내함에 따라 참고하여 코드 짰습니다.
 - viewModel에 useCase 받아서 바로 view로 연결했는데 버그 수정하면서 viewModel 채우고 컨벤션에 맞게 코드 수정하겠습니다.

## 📸 스크린샷
![IMG_4641](https://github.com/user-attachments/assets/da31e0b8-de1a-4227-bc5c-264180195b5e)


## 💡 관련 이슈
- Resolved: #115 
