### PR TITLE
[fix] Toggle 간헐적으로 뜨지 않는 버그 수정 feat: 애플 정책

### DIFF
--- a/AsyncC/Source/Domain/UseCases/AccountManagingUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/AccountManagingUseCase.swift
@@ -179,7 +179,19 @@ final class AccountManagingUseCase: NSObject {
         firebaseRepository.setUsers(id: id, email: email, name: name)
     }
     
-    // MARK: - 유저 이름 변경
+    // MARK: - 유저
+    
+    func getUserName(userID: String, completion: @escaping (Result<String, Error>) -> Void) {
+        firebaseRepository.getUserName(userID: userID) { result in
+            switch result {
+            case .success(let userName):
+                completion(.success(userName))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
     private func changeUserNameToFirebase(name: String) {
         firebaseRepository.updateUsers(id: localRepository.userID, email: nil, name: name)
     }

--- a/AsyncC/Source/Domain/UseCases/AccountManagingUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/AccountManagingUseCase.swift
@@ -57,7 +57,11 @@ final class AccountManagingUseCase: NSObject {
                     if let user = authDataResult?.user {
                         let userID = user.uid
                         let email = user.email
+                        print("Apple 로그인 시점에서의 userID: \(userID)")
+                        print("Apple 로그인 시점에서의 email: \(email ?? "Apple 로그인 시점에서의 email N/A")")
+
                         let fullName = "\(appleIDCredential.fullName?.givenName ?? "") \(appleIDCredential.fullName?.familyName ?? "")".trimmingCharacters(in: .whitespaces)
+                        print("Apple 로그인 시점에서의 userName: \(fullName)")
                         
                         self.firebaseRepository.checkExistUserBy(userID: userID) { exists, name in
                             if exists {

--- a/AsyncC/Source/Extension/Extension + DisbandConfirmation.swift
+++ b/AsyncC/Source/Extension/Extension + DisbandConfirmation.swift
@@ -27,7 +27,7 @@ extension AppDelegate {
         exitConfirmation?.isMovable = false
         exitConfirmation?.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
         exitConfirmation?.level = .popUpMenu
-        exitConfirmation?.contentViewController = NSHostingController(rootView: DisbandConfirmationView(viewModel: MainStatusViewModel(teamManagingUseCase: self.router.teamManagingUseCase, appTrackingUseCase: self.router.appTrackingUseCase, emoticonUseCase: self.router.syncUseCase)).environmentObject(self.router))
+        exitConfirmation?.contentViewController = NSHostingController(rootView: DisbandConfirmationView(viewModel: MainStatusViewModel(teamManagingUseCase: self.router.teamManagingUseCase, appTrackingUseCase: self.router.appTrackingUseCase, emoticonUseCase: self.router.syncUseCase, accountUseCase: self.router.accountManagingUseCase)).environmentObject(self.router))
         
         // Set the CornerRadius for the View inside the NSPanel
         exitConfirmation?.contentView?.wantsLayer = true

--- a/AsyncC/Source/Extension/Extension + ExitConfirmation.swift
+++ b/AsyncC/Source/Extension/Extension + ExitConfirmation.swift
@@ -27,7 +27,7 @@ extension AppDelegate {
         exitConfirmation?.isMovable = false
         exitConfirmation?.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
         exitConfirmation?.level = .popUpMenu
-        exitConfirmation?.contentViewController = NSHostingController(rootView: ExitConfirmationView(viewModel: MainStatusViewModel(teamManagingUseCase: self.router.teamManagingUseCase, appTrackingUseCase: self.router.appTrackingUseCase, emoticonUseCase: self.router.syncUseCase)).environmentObject(self.router))
+        exitConfirmation?.contentViewController = NSHostingController(rootView: ExitConfirmationView(viewModel: MainStatusViewModel(teamManagingUseCase: self.router.teamManagingUseCase, appTrackingUseCase: self.router.appTrackingUseCase, emoticonUseCase: self.router.syncUseCase, accountUseCase: self.router.accountManagingUseCase)).environmentObject(self.router))
         
         // Set the CornerRadius for the View inside the NSPanel
         exitConfirmation?.contentView?.wantsLayer = true

--- a/AsyncC/Source/Extension/Extension + HUDWindow.swift
+++ b/AsyncC/Source/Extension/Extension + HUDWindow.swift
@@ -34,7 +34,8 @@ extension AppDelegate {
                 viewModel: MainStatusViewModel(
                     teamManagingUseCase: self.router.teamManagingUseCase,
                     appTrackingUseCase: self.router.appTrackingUseCase,
-                    emoticonUseCase: self.router.syncUseCase)
+                    emoticonUseCase: self.router.syncUseCase,
+                    accountUseCase: self.router.accountManagingUseCase)
             ).environmentObject(self.router))
         
         // Set the CornerRadius for the View inside the NSPanel

--- a/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamView.swift
+++ b/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct CreateOrJoinTeamView: View {
     @EnvironmentObject var router: Router
-    var viewModel: CreateOrJoinTeamViewModel
+    @ObservedObject var viewModel: CreateOrJoinTeamViewModel
     
     var widthOfButton: CGFloat = 100
     var heightOfButton: CGFloat = 120
@@ -18,7 +18,7 @@ struct CreateOrJoinTeamView: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
-                Text("\(router.localRepository.userName)")
+                Text(viewModel.userName ?? "")
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundStyle(.darkGray2)
                 Spacer()
@@ -51,5 +51,8 @@ struct CreateOrJoinTeamView: View {
         }
         .padding(EdgeInsets(top: 24, leading: 12, bottom: 19, trailing: 12))
         .frame(width: 270, height: 200)
+        .onAppear {
+            viewModel.fetchUserName()
+        }
     }
 }

--- a/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
+++ b/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
@@ -6,12 +6,34 @@
 //
 
 import SwiftUI
+import FirebaseAuth
 
 class CreateOrJoinTeamViewModel: ObservableObject {
     let teamUseCase: TeamManagingUseCase
     let accountUseCase: AccountManagingUseCase
+    @Published var userName: String?
+    
     init(teamUseCase: TeamManagingUseCase, accountUseCase: AccountManagingUseCase) {
         self.teamUseCase = teamUseCase
         self.accountUseCase = accountUseCase
+    }
+    
+    func fetchUserName() {
+        guard let userID = Auth.auth().currentUser?.uid else {
+            print("현재 유저 아이디를 받아올 수 없습니다.")
+            return
+        }
+        
+        accountUseCase.getUserName(userID: userID) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let userName):
+                DispatchQueue.main.async {
+                    self.userName = userName
+                }
+            case .failure(let error):
+                print("Error fetching user name: \(error.localizedDescription)")
+            }
+        }
     }
 }

--- a/AsyncC/Source/Presentation/Flow/Router.swift
+++ b/AsyncC/Source/Presentation/Flow/Router.swift
@@ -55,7 +55,7 @@ class Router: ObservableObject{
             MainStatusView(viewModel: MainStatusViewModel(
                 teamManagingUseCase: self.teamManagingUseCase,
                 appTrackingUseCase: self.appTrackingUseCase,
-                emoticonUseCase: self.syncUseCase))
+                emoticonUseCase: self.syncUseCase, accountUseCase: accountManagingUseCase))
         case .LoginView:
             LoginView(viewModel: LoginViewModel(accountManagingUseCase: accountManagingUseCase))
         case .LogoutView:

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxHeaderView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppIconBoxHeaderView.swift
@@ -27,7 +27,7 @@ struct AppIconBoxHeaderView: View {
             Spacer()
             
             if let userID = viewModel.nameToUserId[key] {
-                if key == viewModel.getUserName() {
+                if key == viewModel.userName {
                     Toggle("", isOn: Binding(
                         get: { viewModel.trackingActive[userID] ?? true },
                         set: { newValue in

--- a/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/Components/AppTrackingBoxView.swift
@@ -34,7 +34,7 @@ extension AppTrackingBoxView {
                                 }
                                 .padding(.trailing, 4)
                             
-                            if viewModel.getUserName() != key {
+                            if viewModel.userName != key {
                                 SyncButton(viewModel: viewModel, key: key, action: {
                                     if let userID = viewModel.userNameAndID[key] {
                                         viewModel.emoticonUseCase.requestForSync(receiver: userID)
@@ -45,7 +45,7 @@ extension AppTrackingBoxView {
                         .padding(.vertical, 4.5)
                         .padding(.horizontal, 16)
                         
-                        if key == viewModel.getUserName() {
+                        if key == viewModel.userName {
                             Rectangle()
                                 .fill(.clear)
                                 .frame(height: 1)
@@ -60,7 +60,7 @@ extension AppTrackingBoxView {
             }
         } else {
             VStack(spacing: 0) {
-                if viewModel.appTrackings[viewModel.getUserName()] != nil {
+                if viewModel.appTrackings[viewModel.userName] != nil {
                     HStack(spacing: 0) {
                         RoundedRectangle(cornerRadius: 6)
                             .fill(.ultraThinMaterial)
@@ -68,8 +68,8 @@ extension AppTrackingBoxView {
                             .frame(width:243, height: 68)
                             .overlay {
                                 VStack(spacing: 0) {
-                                    AppIconBoxHeaderView(viewModel: viewModel, key: viewModel.getUserName())
-                                    AppIconBoxContentView(viewModel: viewModel, key: viewModel.getUserName())
+                                    AppIconBoxHeaderView(viewModel: viewModel, key: viewModel.userName)
+                                    AppIconBoxContentView(viewModel: viewModel, key: viewModel.userName)
                                 }
                             }
                             .padding(.trailing, 4)

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusView.swift
@@ -35,6 +35,7 @@ struct MainStatusView: View {
                 viewModel.getTeamData(teamCode: viewModel.getTeamCode())
                 viewModel.startShowingAppTracking()
                 viewModel.setUpAllListener()
+                viewModel.getUserName()
               
                 // Listener that checks if the room has been disbanded
                 router.teamManagingUseCase.listenToDisbandStatus(teamCode: viewModel.getTeamCode()) { isDisband in

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
@@ -14,14 +14,20 @@
 
 import SwiftUI
 import Combine
+import FirebaseAuth
 
 class MainStatusViewModel: ObservableObject {
     var teamManagingUseCase: TeamManagingUseCase
     var appTrackingUseCase: AppTrackingUseCase
     var emoticonUseCase: SyncUseCase
+    var accountUseCase: AccountManagingUseCase
     
     var cancellables = Set<AnyCancellable>()
-    @Published var nameToUserId: [String: String] = [:]
+    @Published var nameToUserId: [String: String] = [:] {
+        didSet {
+            print("nameToUserId: \(nameToUserId)")
+        }
+    }
     @Published var trackingActive: [String: Bool] = [:] // 유저별 TrackingActive 상태
     @Published var appTrackings: [String: [String]] = [:] {
         didSet {
@@ -29,6 +35,7 @@ class MainStatusViewModel: ObservableObject {
             objectWillChange.send()
         }
     }
+    @Published var userName: String = ""
     @Published var teamName: String = ""
     @Published var hostName: String = ""
     @Published var teamMembers: [String] = []
@@ -39,10 +46,11 @@ class MainStatusViewModel: ObservableObject {
       @Published var isSelectedButton: Bool = false
     @Published var buttonStates: [String: Bool] = [:]
     
-    init(teamManagingUseCase: TeamManagingUseCase, appTrackingUseCase: AppTrackingUseCase, emoticonUseCase: SyncUseCase) {
+    init(teamManagingUseCase: TeamManagingUseCase, appTrackingUseCase: AppTrackingUseCase, emoticonUseCase: SyncUseCase, accountUseCase: AccountManagingUseCase) {
         self.teamManagingUseCase = teamManagingUseCase
         self.appTrackingUseCase = appTrackingUseCase
         self.emoticonUseCase =  emoticonUseCase
+        self.accountUseCase = accountUseCase
         
         appTrackingUseCase.$teamTrackingStatus
             .receive(on: RunLoop.main)
@@ -91,7 +99,7 @@ class MainStatusViewModel: ObservableObject {
     }
     
     func checkUser(key: String) -> Bool {
-        return getUserName() == key
+        return userName == key
     }
     
     func getTeamName() -> String {
@@ -102,8 +110,22 @@ class MainStatusViewModel: ObservableObject {
         teamManagingUseCase.getTeamCode()
     }
     
-    func getUserName() -> String {
-        teamManagingUseCase.getUserName()
+    func getUserName() {
+        guard let userID = Auth.auth().currentUser?.uid else {
+            print("현재 유저 아이디를 받아올 수 없습니다.")
+            return
+        }
+        
+        accountUseCase.getUserName(userID: userID) { [weak self] result in
+            guard let self = self else { return }
+            
+            switch result {
+            case .success(let userName):
+                self.userName = userName
+            case .failure(let error):
+                print("error: \(error.localizedDescription)")
+            }
+        }
     }
     
     func getUserID() -> String {
@@ -187,8 +209,8 @@ class MainStatusViewModel: ObservableObject {
     }
     
     func customSort(lhs: String, rhs: String) -> Bool {
-        if lhs == self.getUserName() { return true }
-        if rhs == self.getUserName() { return false }
+        if lhs == self.userName { return true }
+        if rhs == self.userName { return false }
         
         if lhs == self.hostName { return true }
         if rhs == self.hostName { return false }


### PR DESCRIPTION
## ✅ 작업한 내용
 - 현재 내 실행 프로그램 Active Toggle이 어떤 사람은 뜨고 어떤 사람은 안뜨는 버그를 발견했습니다.
 - 애플 로그인은 최초 로그인에만 유저 이름을 반환하고 그 이후에는 반환하지 않는데요. 저희 로직 상 로컬에 유저의 이름을 저장하고 그것을 통해 여러 분기를 처리했는데요.
 - 이전에는 로그아웃과 탈퇴기능이 없었기 때문에 이와 같은 문제를 발견하지 못했지만 추가된 이후로 위와같이 로그아웃 시 로컬에 들어있는 유저에 대한 정보를 전부 초기화 시키기 때문에 그 다음 로그인에는 UserName이 nil값으로 들어와 버그가 발생했습니다.
 - 해결방법: 최초 애플 로그인 시 받을 수 있는 유저 이름을 DB에서 필요 시 불러와 명시적으로 값이 들어오게 변경하였습니다. 

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - 위와 같은 방법이 명시적이고 버그가 없어지는 방법임에는 확실하지만 가장 효율적인 방법이냐고 물어보시면 No입니다. 그래서 더 좋은 방법이 있으신분은 의견 주시면 감사하겠습니다.

## 📸 스크린샷
<img width="291" alt="스크린샷 2024-11-29 오후 12 27 55" src="https://github.com/user-attachments/assets/3446d436-8c07-4326-8949-eccc95d77e25">


## 💡 관련 이슈
- Resolved: #119 
