### PR TITLE
[fix] 최초 로그인 시 이름 표출 안되는 버그 수정

### DIFF
--- a/AsyncC.xcodeproj/project.pbxproj
+++ b/AsyncC.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		6B8F682C2CDB08220036B936 /* FirebaseFirestoreCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 6B8F682B2CDB08220036B936 /* FirebaseFirestoreCombine-Community */; };
 		6B8F682E2CDB08220036B936 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 6B8F682D2CDB08220036B936 /* FirebaseStorage */; };
 		6B8F68302CDB08220036B936 /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 6B8F682F2CDB08220036B936 /* FirebaseStorageCombine-Community */; };
-		B17F3A5F2CF768E200C65BD3 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B17F3A5E2CF768E200C65BD3 /* FirebaseAuth */; };
+		CCACF0C22CF468F400AE5BC1 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = CCACF0C12CF468F400AE5BC1 /* FirebaseAuth */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,7 +67,7 @@
 				6B8F68262CDB08220036B936 /* FirebaseCore in Frameworks */,
 				6B8F682E2CDB08220036B936 /* FirebaseStorage in Frameworks */,
 				6B8F68302CDB08220036B936 /* FirebaseStorageCombine-Community in Frameworks */,
-				B17F3A5F2CF768E200C65BD3 /* FirebaseAuth in Frameworks */,
+				CCACF0C22CF468F400AE5BC1 /* FirebaseAuth in Frameworks */,
 				6B8F682A2CDB08220036B936 /* FirebaseFirestore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -89,20 +89,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		B17F3A5D2CF768E200C65BD3 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		CC0F1A182CDA671E00562085 = {
 			isa = PBXGroup;
 			children = (
 				CC0F1A232CDA671E00562085 /* AsyncC */,
 				CC0F1A352CDA671F00562085 /* AsyncCTests */,
 				CC0F1A3F2CDA671F00562085 /* AsyncCUITests */,
-				B17F3A5D2CF768E200C65BD3 /* Frameworks */,
+				CCACF0C02CF468F400AE5BC1 /* Frameworks */,
 				CC0F1A222CDA671E00562085 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -115,6 +108,13 @@
 				CC0F1A3C2CDA671F00562085 /* AsyncCUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		CCACF0C02CF468F400AE5BC1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -143,7 +143,7 @@
 				6B8F682B2CDB08220036B936 /* FirebaseFirestoreCombine-Community */,
 				6B8F682D2CDB08220036B936 /* FirebaseStorage */,
 				6B8F682F2CDB08220036B936 /* FirebaseStorageCombine-Community */,
-				B17F3A5E2CF768E200C65BD3 /* FirebaseAuth */,
+				CCACF0C12CF468F400AE5BC1 /* FirebaseAuth */,
 			);
 			productName = AsyncC;
 			productReference = CC0F1A212CDA671E00562085 /* AsyncC.app */;
@@ -428,6 +428,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = AsyncC/AsyncC.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -438,6 +439,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -459,6 +461,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = AsyncC/AsyncC.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -469,6 +472,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -635,7 +639,7 @@
 			package = 6B8F68242CDB08220036B936 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = "FirebaseStorageCombine-Community";
 		};
-		B17F3A5E2CF768E200C65BD3 /* FirebaseAuth */ = {
+		CCACF0C12CF468F400AE5BC1 /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 6B8F68242CDB08220036B936 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAuth;

--- a/AsyncC/Source/Domain/UseCases/AccountManagingUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/AccountManagingUseCase.swift
@@ -50,8 +50,6 @@ final class AccountManagingUseCase: NSObject {
                         print("Error during Firebase Sign-In: \(error.localizedDescription)")
                         return
                     }
-                    
-                    NotificationCenter.default.post(name: .AuthStateDidChange, object: nil)
 
                     let firebaseUser = Auth.auth().currentUser
                     let fbName = firebaseUser?.displayName
@@ -71,12 +69,14 @@ final class AccountManagingUseCase: NSObject {
                                     self.saveUserIDToLocal(userID: userID)
                                     self.saveUserNameToLocal(userName: fbName ?? "N/A")
                                     print("User exists in Firebase. Fetched name: \(name)")
+                                    NotificationCenter.default.post(name: .AuthStateDidChange, object: nil)
                                 }
                             } else {
                                 self.saveUserIDToLocal(userID: userID)
                                 self.saveUserNameToLocal(userName: fbName ?? "N/A")
                                 self.saveUserIDToFirebase(id: userID, email: email ?? "N/A", name: fullName.isEmpty ? "N/A" : fullName)
                                 print("User not found in Firebase. Saved new user with name: \(fullName)")
+                                NotificationCenter.default.post(name: .AuthStateDidChange, object: nil)
                             }
                         }
                     }

--- a/AsyncC/Source/Domain/UseCases/AccountManagingUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/AccountManagingUseCase.swift
@@ -51,6 +51,8 @@ final class AccountManagingUseCase: NSObject {
                         return
                     }
                     
+                    NotificationCenter.default.post(name: .AuthStateDidChange, object: nil)
+
                     let firebaseUser = Auth.auth().currentUser
                     let fbName = firebaseUser?.displayName
                     

--- a/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamView.swift
+++ b/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamView.swift
@@ -51,8 +51,5 @@ struct CreateOrJoinTeamView: View {
         }
         .padding(EdgeInsets(top: 24, leading: 12, bottom: 19, trailing: 12))
         .frame(width: 270, height: 200)
-        .onAppear {
-            viewModel.fetchUserName()
-        }
     }
 }

--- a/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamView.swift
+++ b/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamView.swift
@@ -51,5 +51,8 @@ struct CreateOrJoinTeamView: View {
         }
         .padding(EdgeInsets(top: 24, leading: 12, bottom: 19, trailing: 12))
         .frame(width: 270, height: 200)
+        .onAppear {
+            viewModel.fetchUserName()
+        }
     }
 }

--- a/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
+++ b/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
@@ -11,11 +11,7 @@ import FirebaseAuth
 class CreateOrJoinTeamViewModel: ObservableObject {
     let teamUseCase: TeamManagingUseCase
     let accountUseCase: AccountManagingUseCase
-    @Published var userName: String? {
-        didSet {
-            print("CreateOrJoinTeam.userName: \(userName ?? "N/A")")
-        }
-    }
+    @Published var userName: String?
     
     init(teamUseCase: TeamManagingUseCase, accountUseCase: AccountManagingUseCase) {
         self.teamUseCase = teamUseCase
@@ -29,7 +25,6 @@ class CreateOrJoinTeamViewModel: ObservableObject {
     }
     
     @objc private func onAuthStateChanged() {
-            print("Auth state changed, fetching user name...")
             self.fetchUserName()
         }
     

--- a/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
+++ b/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
@@ -29,7 +29,6 @@ class CreateOrJoinTeamViewModel: ObservableObject {
         }
     
     func fetchUserName() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             guard let userID = Auth.auth().currentUser?.uid else {
                 print("CreateOrJoinTeamViewModel: 현재 유저 아이디를 받아올 수 없습니다.")
                 return
@@ -44,7 +43,6 @@ class CreateOrJoinTeamViewModel: ObservableObject {
                     }
                 case .failure(let error):
                     print("Error fetching user name: \(error.localizedDescription)")
-                }
             }
         }
     }

--- a/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
+++ b/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
@@ -29,6 +29,7 @@ class CreateOrJoinTeamViewModel: ObservableObject {
         }
     
     func fetchUserName() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             guard let userID = Auth.auth().currentUser?.uid else {
                 print("CreateOrJoinTeamViewModel: 현재 유저 아이디를 받아올 수 없습니다.")
                 return
@@ -43,6 +44,7 @@ class CreateOrJoinTeamViewModel: ObservableObject {
                     }
                 case .failure(let error):
                     print("Error fetching user name: \(error.localizedDescription)")
+                }
             }
         }
     }

--- a/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
+++ b/AsyncC/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
@@ -16,12 +16,8 @@ class CreateOrJoinTeamViewModel: ObservableObject {
     init(teamUseCase: TeamManagingUseCase, accountUseCase: AccountManagingUseCase) {
         self.teamUseCase = teamUseCase
         self.accountUseCase = accountUseCase
-        
+
         NotificationCenter.default.addObserver(self, selector: #selector(onAuthStateChanged), name: .AuthStateDidChange, object: nil)
-    }
-    
-    deinit {
-        NotificationCenter.default.removeObserver(self, name: .AuthStateDidChange, object: nil)
     }
     
     @objc private func onAuthStateChanged() {
@@ -29,7 +25,7 @@ class CreateOrJoinTeamViewModel: ObservableObject {
         }
     
     func fetchUserName() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             guard let userID = Auth.auth().currentUser?.uid else {
                 print("CreateOrJoinTeamViewModel: 현재 유저 아이디를 받아올 수 없습니다.")
                 return
@@ -44,6 +40,7 @@ class CreateOrJoinTeamViewModel: ObservableObject {
                     }
                 case .failure(let error):
                     print("Error fetching user name: \(error.localizedDescription)")
+                    self.userName = "Guest"
                 }
             }
         }

--- a/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
+++ b/AsyncC/Source/Presentation/MainStatusView/MainStatusViewModel.swift
@@ -112,7 +112,7 @@ class MainStatusViewModel: ObservableObject {
     
     func getUserName() {
         guard let userID = Auth.auth().currentUser?.uid else {
-            print("현재 유저 아이디를 받아올 수 없습니다.")
+            print("MainStatusViewModel: 현재 유저 아이디를 받아올 수 없습니다.")
             return
         }
         


### PR DESCRIPTION
## ✅ 작업한 내용
 - 애플 로그인시 NotificationCenter를 통해 명시적으로 로그인 했다는 것을 옵저버에게 알려주어 Auth에 현재 유저 정보가 담길 때 CreateOrJoinTeamViewModel의 fetchName이 동작하도록 수정 

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - Firebase Auth의 동작이 대부분 비동기로 동작되어 Auth에 유저 정보가 담기지 않은 상태에서 fetchName이 진행되는 버그 발생
 - Notification으로 명시적으로 시점을 알려줘서 Auth에 정보가 담겼을 때 로직이 동작되도록 수정
 - fetchName thread delay를 통해 비동기 작업 우선순위가 바뀌지 않도록 수정

## 📸 스크린샷
<img width="282" alt="스크린샷 2024-12-01 오후 6 36 44" src="https://github.com/user-attachments/assets/d4c2ed35-a419-4235-a867-66600dae430b">


## 💡 관련 이슈
- Resolved: #125 
