### PR TITLE
[#124] - 이미 실행했던 앱을 실행하면 최근 2개만 보여주는거 고침

### DIFF
--- a/AsyncC/Source/Domain/UseCases/AppTrackingUseCase.swift
+++ b/AsyncC/Source/Domain/UseCases/AppTrackingUseCase.swift
@@ -135,8 +135,8 @@ final class AppTrackingUseCase: ObservableObject {
             if !uniqueApps.contains(appName) {
                 uniqueApps.insert(appName)
                 arrayOfLatestApps[count] = appName
+                count -= 1
             }
-            count -= 1
         }
         arrayOfLatestApps.removeAll(where: {$0 == ""})
         teamMemberAppTrackings[userID] = arrayOfLatestApps


### PR DESCRIPTION
## ✅ 작업한 내용
 - 이미 실행했던 앱을 실행하면 최근 2개만 보여주는거 고침

## 💡 관련 이슈
- Resolved: #124
