### PR TITLE
[#144] 팀 나가기 버튼 UI 및 위치 조정

### DIFF
--- a/Oz.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Oz.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,123 @@
+{
+  "originHash" : "c63c63846d9c539229e96de38d6af51417e28c0ee9a0bc48bd0f0f19d923c329",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version" : "1.2024011602.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "8328630971a8fdd8072b36bb22bef732eb15e1f0",
+        "version" : "11.4.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "4f234bcbdae841d7015258fbbf8e7743a39b8200",
+        "version" : "11.4.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
+        "version" : "8.0.2"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
+        "version" : "1.65.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "5cfe5f090c982de9c58605d2a82a4fc77b774fbd",
+        "version" : "4.1.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
+        "version" : "1.28.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Oz/Resource/Assets.xcassets/Color/LeaveRoomText.colorset/Contents.json
+++ b/Oz/Resource/Assets.xcassets/Color/LeaveRoomText.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x94",
+          "green" : "0x94",
+          "red" : "0x94"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Oz/Resource/GoogleService-Info.plist
+++ b/Oz/Resource/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyBfDpI1azF8_52xnR2PP2Ge1MDuOySwY8A</string>
+	<key>GCM_SENDER_ID</key>
+	<string>300955754553</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.PohangEgrets.AsyncC</string>
+	<key>PROJECT_ID</key>
+	<string>asyncc-eded1</string>
+	<key>STORAGE_BUCKET</key>
+	<string>asyncc-eded1.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:300955754553:ios:51af7dbe3b3e6a1da2ade8</string>
+</dict>
+</plist>

--- a/Oz/Source/Extension/Extension + ContentViewWindow.swift
+++ b/Oz/Source/Extension/Extension + ContentViewWindow.swift
@@ -27,7 +27,7 @@ extension AppDelegate {
         contentViewWindow?.appearance = NSAppearance(named: .aqua)
         contentViewWindow?.level = .floating
         contentViewWindow?.center()
-        contentViewWindow?.title = "Sync"
+        contentViewWindow?.title = "Oz"
         contentViewWindow?.isReleasedWhenClosed = false
         contentViewWindow?.contentView = NSHostingView(rootView: ContentView().environmentObject(self.router))
         contentViewWindow?.makeKeyAndOrderFront(nil)

--- a/Oz/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
+++ b/Oz/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
@@ -16,20 +16,12 @@ struct TeamCodeView: View {
             HStack {
                 Text(viewModel.getTeamName())
                     .font(.system(size: 20, weight: .medium))
-                    .padding(.horizontal, 16)
                     .foregroundStyle(.darkGray2)
+                    .lineLimit(1)
                 Spacer()
-                
-                Button {
-                    performActionBasedOnRole()
-                } label: {
-                    Image(systemName: "chevron.right")
-                        .resizable()
-                        .scaledToFit()
-                        .foregroundStyle(.darkGray1)
-                        .frame(height: 16)
+                if viewModel.isTeamHost {
+                    ChangeTeamNameButton()
                 }
-                .buttonStyle(.plain)
             }
             .padding(.top, 20)
 
@@ -55,27 +47,21 @@ struct TeamCodeView: View {
             }
             .foregroundStyle(.gray1)
             .padding(.top, 12)
-            .padding(.horizontal, 16)
         }
+        .padding(.horizontal, 16)
     }
     
-    // Action that behaves differently when the 'Leave' button is pressed based on whether the user is a host
-    func performActionBasedOnRole() {
-        if viewModel.isTeamHost {
-            if !((router.exitConfirmation()?.isVisible) != nil) {
-                router.setUpDisbandConfirmation()
-                router.showDisbandConfirmation()
-            } else {
-                router.closeDisbandConfirmation()
-            }
-        } else {
-            if !((router.exitConfirmation()?.isVisible) != nil) {
-                router.setUpExitConfirmation()
-                router.showExitConfirmation()
-            } else {
-                router.closeExitConfirmation()
-            }
+    func ChangeTeamNameButton() -> some View {
+        Button {
+            
+        } label: {
+            Image(systemName: "pencil")
+                .resizable()
+                .scaledToFit()
+                .foregroundStyle(.darkGray1)
+                .frame(height: 16)
         }
+        .buttonStyle(.plain)
     }
 }
 

--- a/Oz/Source/Presentation/MainStatusView/MainStatusView.swift
+++ b/Oz/Source/Presentation/MainStatusView/MainStatusView.swift
@@ -29,6 +29,7 @@ struct MainStatusView: View {
                     .padding(.vertical, 12)
                 
                 AppTrackingBoxView(viewModel: viewModel)
+                LeaveTeamButtonOnRole()
             }
             .frame(width: 270)
             .onAppear {
@@ -54,6 +55,29 @@ struct MainStatusView: View {
             }
         }
         .fixedSize(horizontal: false, vertical: true)
+    }
+    
+    func LeaveTeamButtonOnRole() -> some View {
+            Button {
+                if viewModel.isTeamHost {
+                    viewModel.disbandTeam()
+                } else {
+                    viewModel.leaveTeam()
+                    router.closeHUDWindow()
+                    router.removeStatusBarItem()
+                    router.setUpContentViewWindow()
+                    router.closeExitConfirmation()
+                }
+            } label: {
+                Text(viewModel.isTeamHost ? "팀 해체하기" : "팀 나가기")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(viewModel.isLeaveRoomTextHover ? .systemBlue : .leaveRoomText)
+                    .onHover { hovering in
+                        viewModel.isLeaveRoomTextHover = hovering
+                    }
+                    .padding(.bottom, 16)
+            }
+            .buttonStyle(.plain)
     }
 }
 

--- a/Oz/Source/Presentation/MainStatusView/MainStatusViewModel.swift
+++ b/Oz/Source/Presentation/MainStatusView/MainStatusViewModel.swift
@@ -46,6 +46,7 @@ class MainStatusViewModel: ObservableObject {
     @Published var isSelectedButton: Bool = false
     @Published var buttonStates: [String: Bool] = [:]
     @Published var isAppIconHover: Bool = false
+    @Published var isLeaveRoomTextHover: Bool = false
     
     init(teamManagingUseCase: TeamManagingUseCase, appTrackingUseCase: AppTrackingUseCase, syncUseCase: SyncUseCase, accountUseCase: AccountManagingUseCase) {
         self.teamManagingUseCase = teamManagingUseCase


### PR DESCRIPTION
## ✅ 작업한 내용
### #144 변경사항
- 팀 나가기 버튼 UI 및 위치 조정
- 호버에 따른 색상 변경 적용
- 버튼에 함수 배정
---
### 기타 변경사항
- contentViewWindow?.title을 Oz로 변경
- LeaveRoomText 컬러 추가
// - 팀 나가기 새창 생성 Extension인 ExitConfirmation.swift 파일 삭제
// - 팀 해체하기 새창 생성 Extension인 DisbandConfirmation.swift 파일 삭제
- 팀 호스트 여부에 따라 새창을 띄우던 performActionBasedOnRole() 함수 삭제

## 📸 스크린샷
<img width="316" alt="스크린샷 2025-01-16 오후 8 35 10" src="https://github.com/user-attachments/assets/609f0d13-734b-4a7d-9a02-3186ecb9ddca" />


## 💡 관련 이슈
- Resolved: #144 
