### PR TITLE
[#147] 팀코드 복사 알러트 구현

### DIFF
--- a/Oz/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
+++ b/Oz/Source/Presentation/MainStatusView/Components/TeamCodeView.swift
@@ -12,41 +12,44 @@ struct TeamCodeView: View {
     @EnvironmentObject var router: Router
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Text(viewModel.getTeamName())
-                    .font(.system(size: 20, weight: .medium))
-                    .foregroundStyle(.darkGray2)
-                    .lineLimit(1)
-                Spacer()
-                if viewModel.isTeamHost {
-                    ChangeTeamNameButton()
+        ZStack {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Text(viewModel.getTeamName())
+                        .font(.system(size: 20, weight: .medium))
+                        .foregroundStyle(.darkGray2)
+                        .lineLimit(1)
+                    Spacer()
+                    if viewModel.isTeamHost {
+                        ChangeTeamNameButton()
+                    }
                 }
-            }
-            .padding(.top, 20)
-
-            
-            HStack(alignment: .bottom, spacing: 0){
-                Text("팀 코드:")
-                    .font(.system(size: 12, weight: .medium))
-                    .padding(.trailing, 8)
+                .padding(.top, 20)
                 
-                Text(viewModel.getTeamCode())
-                    .font(.system(size: 12, weight: .semibold))
-                    .padding(.trailing, 2)
                 
-                Button {
-                    viewModel.copyTeamCode()
-                } label: {
-                    Image(systemName: "document.on.document")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 15, height: 15)
+                HStack(alignment: .bottom, spacing: 0){
+                    Text("팀 코드:")
+                        .font(.system(size: 12, weight: .medium))
+                        .padding(.trailing, 8)
+                    
+                    Text(viewModel.getTeamCode())
+                        .font(.system(size: 12, weight: .semibold))
+                        .padding(.trailing, 2)
+                    
+                    Button {
+                        viewModel.copyTeamCode()
+                    } label: {
+                        Image(systemName: "document.on.document")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 15, height: 15)
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
+                .foregroundStyle(.gray1)
+                .padding(.top, 12)
             }
-            .foregroundStyle(.gray1)
-            .padding(.top, 12)
+            CopyTeamCodeAlert()
         }
         .padding(.horizontal, 16)
     }
@@ -62,6 +65,24 @@ struct TeamCodeView: View {
                 .frame(height: 16)
         }
         .buttonStyle(.plain)
+    }
+    
+    @ViewBuilder
+    func CopyTeamCodeAlert() -> some View {
+        if viewModel.isCopyTeamCode {
+            HStack {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(.regularMaterial)
+                        .frame(width: 96, height: 18)
+                    Text("팀 코드를 복사했습니다.")
+                        .font(.system(size: 8, weight: .regular))
+                }
+                .offset(y:49)
+                .shadow(color: .black.opacity(0.15), radius: 6)
+                Spacer()
+            }
+        }
     }
 }
 

--- a/Oz/Source/Presentation/MainStatusView/MainStatusViewModel.swift
+++ b/Oz/Source/Presentation/MainStatusView/MainStatusViewModel.swift
@@ -47,6 +47,17 @@ class MainStatusViewModel: ObservableObject {
     @Published var buttonStates: [String: Bool] = [:]
     @Published var isAppIconHover: Bool = false
     @Published var isLeaveRoomTextHover: Bool = false
+    @Published var isCopyTeamCode: Bool = false {
+        didSet {
+            if isCopyTeamCode == true {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    withAnimation(.easeInOut(duration: 0.5)) {
+                        self.isCopyTeamCode = false
+                    }
+                }
+            }
+        }
+    }
     
     init(teamManagingUseCase: TeamManagingUseCase, appTrackingUseCase: AppTrackingUseCase, syncUseCase: SyncUseCase, accountUseCase: AccountManagingUseCase) {
         self.teamManagingUseCase = teamManagingUseCase
@@ -225,6 +236,7 @@ class MainStatusViewModel: ObservableObject {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(self.getTeamCode(), forType: .string)
+        isCopyTeamCode = true
         print("팀 코드 복사")
     }
     


### PR DESCRIPTION
## ✅ 작업한 내용
 - 팀코드 복사 알러트 구현

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - viewModel에 isCopyTeamCode 변수를 추가했습니다.
 - 기존 CopyTeamCode() 함수에 팀코드 복사가 되면 isCopyTeamCode를 true로 설정되게 했습니다.
 - isCopyTeamCode 변수에는 didset을 사용해 true가 된다면 몇초 뒤 자동으로 false가 되게 했습니다.
 - isCopyTeamCode 변수를 분기 조건으로 사용하여 알러트를 구현하였습니다.

## 📸 스크린샷
![화면 기록 2025-01-17 오후 10 14 00](https://github.com/user-attachments/assets/9f19855e-a927-46e6-ad68-82e21801332e)


## 💡 관련 이슈
- Resolved: #147 
