### PR TITLE
[#145] 로그인 로그아웃 회원탈퇴 모든 예외처리

### DIFF
--- a/Oz/Source/Data/Repositories/LocalRepository.swift
+++ b/Oz/Source/Data/Repositories/LocalRepository.swift
@@ -12,6 +12,7 @@ final class LocalRepository: LocalRepositoryProtocol {
     @AppStorage("userName") var userName: String = ""
     @AppStorage("teamName") var teamName: String = ""
     @AppStorage("teamCode") private var _teamCode: String = ""
+    @AppStorage("firstSignIn") var firstSignIn: Bool = true
     
     var teamCode: String? {
         get {
@@ -54,6 +55,14 @@ final class LocalRepository: LocalRepositoryProtocol {
         teamName = inputTeamName
     }
     
+    func saveFirstSignIn(_ isFirstSignIn: Bool) {
+        self.firstSignIn = isFirstSignIn
+    }
+    
+    func getFirstSignIn() -> Bool {
+        return firstSignIn
+    }
+    
     func getTeamName() -> String {
         return teamName
     }
@@ -65,6 +74,7 @@ final class LocalRepository: LocalRepositoryProtocol {
     func clearLocalUserData() {
         self.saveUserID("")
         self.saveUserName("")
+        self.saveFirstSignIn(true)
     }
 }
 

--- a/Oz/Source/Domain/RepositoryInterfaces/LocalRepositoryProtocol.swift
+++ b/Oz/Source/Domain/RepositoryInterfaces/LocalRepositoryProtocol.swift
@@ -28,6 +28,10 @@ protocol LocalRepositoryProtocol {
     
     func getTeamName() -> String
     
+    func getFirstSignIn() -> Bool
+    
+    func saveFirstSignIn(_ isFirstSignIn: Bool)
+    
     func resetTeamCode()
     
     func resetTeamName()

--- a/Oz/Source/Domain/UseCases/AccountManagingUseCase.swift
+++ b/Oz/Source/Domain/UseCases/AccountManagingUseCase.swift
@@ -9,6 +9,7 @@ import AuthenticationServices
 import CryptoKit
 import FirebaseAuth
 import FirebaseFirestore
+import SwiftUI
 
 final class AccountManagingUseCase: NSObject {
     fileprivate var currentNonce: String?
@@ -110,8 +111,12 @@ final class AccountManagingUseCase: NSObject {
     
     // MARK: - 회원탈퇴
     func deleteFirebaseAuthUser() async -> Bool {
-        guard let user = Auth.auth().currentUser else { return false }
-        guard let lastSignInDate = user.metadata.lastSignInDate else { return false }
+        guard let user = Auth.auth().currentUser else {
+            return false
+        }
+        guard let lastSignInDate = user.metadata.lastSignInDate else {
+            return false
+        }
         
         let needsReauth = !lastSignInDate.isWithinPast(minutes: 5)
         let needsTokenRevocation = user.providerData.contains { $0.providerID == "apple.com" }
@@ -168,6 +173,7 @@ final class AccountManagingUseCase: NSObject {
             }
         } catch {
             print("유저 삭제 실패")
+            return false
         }
         return true
     }

--- a/Oz/Source/Domain/UseCases/AccountManagingUseCase.swift
+++ b/Oz/Source/Domain/UseCases/AccountManagingUseCase.swift
@@ -191,6 +191,14 @@ final class AccountManagingUseCase: NSObject {
         firebaseRepository.setUsers(id: id, email: email, name: name)
     }
     
+    public func getFirstSignIn() -> Bool {
+        return localRepository.getFirstSignIn()
+    }
+    
+    public func saveFirstSignIn(firstSignIn: Bool) {
+        return localRepository.saveFirstSignIn(firstSignIn)
+    }
+    
     // MARK: - 유저
     
     func getUserName(userID: String, completion: @escaping (Result<String, Error>) -> Void) {

--- a/Oz/Source/Presentation/ChangeName/ChangeNameView.swift
+++ b/Oz/Source/Presentation/ChangeName/ChangeNameView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ChangeNameView: View {
-    @EnvironmentObject var router: Router    
+    @EnvironmentObject var router: Router
     @ObservedObject var viewModel: ChangeNameViewModel
     
     var body: some View {
@@ -36,9 +36,16 @@ struct ChangeNameView: View {
                     router.pop()
                 }
                 .customButtonStyle(backgroundColor: .white, foregroundColor: .darkGray2)
+                
                 Button("수정") {
                     viewModel.changeName(to: viewModel.nickName)
-                    router.pop()
+                    if viewModel.isLoginView {
+                        print("LoginView에서의 접근이 아님")
+                        router.push(view: .CreateOrJoinTeamView)
+                    } else {
+                        print("LoginView에서의 접근")
+                        router.pop()
+                    }
                 }
                 .customButtonStyle(backgroundColor: .systemBlue, foregroundColor: .white)
                 .disabled(viewModel.nickName.isEmpty)

--- a/Oz/Source/Presentation/ChangeName/ChangeNameView.swift
+++ b/Oz/Source/Presentation/ChangeName/ChangeNameView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ChangeNameView: View {
-    @EnvironmentObject var router: Router
+    @EnvironmentObject var router: Router    
     @ObservedObject var viewModel: ChangeNameViewModel
     
     var body: some View {
@@ -32,20 +32,20 @@ struct ChangeNameView: View {
             Spacer()
             HStack {
                 Spacer()
-                Button("취소") {
-                    router.pop()
-                }
-                .customButtonStyle(backgroundColor: .white, foregroundColor: .darkGray2)
+                    Button("취소") {
+                        router.pop()
+                    }
+                    .customButtonStyle(backgroundColor: .white, foregroundColor: .darkGray2)
                 
                 Button("수정") {
                     viewModel.changeName(to: viewModel.nickName)
-                    if viewModel.isLoginView {
-                        print("LoginView에서의 접근이 아님")
-                        router.push(view: .CreateOrJoinTeamView)
-                    } else {
-                        print("LoginView에서의 접근")
+//                    if viewModel.isLoginView {
+//                        print("LoginView에서 접근")
                         router.pop()
-                    }
+//                    } else {
+//                        print("LoginView에서의 접근이 아님")
+                        router.push(view: .CreateOrJoinTeamView)
+//                    }
                 }
                 .customButtonStyle(backgroundColor: .systemBlue, foregroundColor: .white)
                 .disabled(viewModel.nickName.isEmpty)

--- a/Oz/Source/Presentation/ChangeName/ChangeNameViewModel.swift
+++ b/Oz/Source/Presentation/ChangeName/ChangeNameViewModel.swift
@@ -14,18 +14,18 @@ class ChangeNameViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
 
     @Published var nickName: String = ""
-    @Published var isLoginView: Bool = false
+//    @Published var isLoginView: Bool = false
     
     init(accountUseCase: AccountManagingUseCase, loginViewModel: LoginViewModel) {
         self.accountUseCase = accountUseCase
         self.loginViewModel = loginViewModel
         
-        loginViewModel.$isLoginView
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] newValue in
-                self?.isLoginView = newValue
-            }
-            .store(in: &cancellables)
+//        loginViewModel.$isLoginView
+//            .receive(on: DispatchQueue.main)
+//            .sink { [weak self] newValue in
+//                self?.isLoginView = newValue
+//            }
+//            .store(in: &cancellables)
     }
     
     func changeName(to name: String) {

--- a/Oz/Source/Presentation/ChangeName/ChangeNameViewModel.swift
+++ b/Oz/Source/Presentation/ChangeName/ChangeNameViewModel.swift
@@ -6,13 +6,26 @@
 //
 
 import SwiftUI
+import Combine
 
 class ChangeNameViewModel: ObservableObject {
     let accountUseCase: AccountManagingUseCase
+    let loginViewModel: LoginViewModel
+    private var cancellables = Set<AnyCancellable>()
+
     @Published var nickName: String = ""
+    @Published var isLoginView: Bool = false
     
-    init(accountUseCase: AccountManagingUseCase) {
+    init(accountUseCase: AccountManagingUseCase, loginViewModel: LoginViewModel) {
         self.accountUseCase = accountUseCase
+        self.loginViewModel = loginViewModel
+        
+        loginViewModel.$isLoginView
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newValue in
+                self?.isLoginView = newValue
+            }
+            .store(in: &cancellables)
     }
     
     func changeName(to name: String) {

--- a/Oz/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
+++ b/Oz/Source/Presentation/CreateOrJoinTeam/CreateOrJoinTeamViewModel.swift
@@ -25,7 +25,7 @@ class CreateOrJoinTeamViewModel: ObservableObject {
         }
     
     func fetchUserName() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             guard let userID = Auth.auth().currentUser?.uid else {
                 print("CreateOrJoinTeamViewModel: 현재 유저 아이디를 받아올 수 없습니다.")
                 return

--- a/Oz/Source/Presentation/Flow/Router.swift
+++ b/Oz/Source/Presentation/Flow/Router.swift
@@ -71,7 +71,7 @@ class Router: ObservableObject{
         case .AccountDeleteView:
             AccountDeleteView(viewModel: LoginViewModel(accountManagingUseCase: accountManagingUseCase))
         case .ChangeNameView:
-            ChangeNameView(viewModel: ChangeNameViewModel(accountUseCase: accountManagingUseCase))
+            ChangeNameView(viewModel: ChangeNameViewModel(accountUseCase: accountManagingUseCase, loginViewModel: LoginViewModel(accountManagingUseCase: accountManagingUseCase)))
         }
     }
     

--- a/Oz/Source/Presentation/Login/AccountDeleteView.swift
+++ b/Oz/Source/Presentation/Login/AccountDeleteView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct AccountDeleteView: View {
     @EnvironmentObject var router: Router
     @ObservedObject var viewModel: LoginViewModel
-
+    
     var body: some View {
         VStack {
             Text("SyncC")
@@ -33,8 +33,13 @@ struct AccountDeleteView: View {
                     Button {
                         // MARK: - 회원 탈퇴 로직
                         Task {
-                            await viewModel.accountManagingUseCase.deleteFirebaseAuthUser()
-                            router.push(view: .LoginView)
+                            let delet = await viewModel.deleteFirebaseAuthUser()
+                            
+                            if delet {
+                                router.push(view: .LoginView)
+                            } else {
+                                router.pop()
+                            }
                         }
                     } label: {
                         Text("회원탈퇴")

--- a/Oz/Source/Presentation/Login/LoginView.swift
+++ b/Oz/Source/Presentation/Login/LoginView.swift
@@ -23,16 +23,9 @@ struct LoginView: View {
                 .padding(.top, 48)
             
             SignInWithAppleButton(onRequest: { request in
-                viewModel.accountManagingUseCase.handleSignInWithApple(request: request)
+                viewModel.handleSignInWithApple(request: request)
             }, onCompletion: { result in
-                viewModel.accountManagingUseCase.handleSignInWithAppleCompletion(result: result)
-                Auth.auth().addStateDidChangeListener { auth, user in
-                    if let user = user {
-                        router.push(view: .CreateOrJoinTeamView)
-                    } else {
-                        print("아직 로그인하지 않았습니다.")
-                    }
-                }
+                viewModel.handleSignInWithAppleCompletion(result: result)
             })
             .frame(width: 120, height: 28)
             .padding(.top, 28)
@@ -40,6 +33,14 @@ struct LoginView: View {
             Spacer()
         }
         .frame(width: 270, height: 200)
+        .onChange(of: viewModel.shouldNavigateToChangeNameView) { shouldNavigate in
+            if shouldNavigate && viewModel.isLoginView {
+                router.push(view: .ChangeNameView)
+            }
+        }
+        .onAppear {
+            viewModel.isLoginView = true
+        }
     }
 }
 

--- a/Oz/Source/Presentation/Login/LoginView.swift
+++ b/Oz/Source/Presentation/Login/LoginView.swift
@@ -44,10 +44,6 @@ struct LoginView: View {
                 print("팀 생성 참가로 이동")
                 router.push(view: .CreateOrJoinTeamView)
             }
-            
-            if viewModel.shouldNavigateToChangeNameView && viewModel.isSignOut  {
-                print("로그아웃 이후 팀 생성 참가로 이동")
-            }
         }
     }
 }

--- a/Oz/Source/Presentation/Login/LoginView.swift
+++ b/Oz/Source/Presentation/Login/LoginView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AuthenticationServices
+import FirebaseAuth
 
 struct LoginView: View {
     @EnvironmentObject var router: Router
@@ -25,7 +26,13 @@ struct LoginView: View {
                 viewModel.accountManagingUseCase.handleSignInWithApple(request: request)
             }, onCompletion: { result in
                 viewModel.accountManagingUseCase.handleSignInWithAppleCompletion(result: result)
-                router.push(view: .CreateOrJoinTeamView)
+                Auth.auth().addStateDidChangeListener { auth, user in
+                    if let user = user {
+                        router.push(view: .CreateOrJoinTeamView)
+                    } else {
+                        print("아직 로그인하지 않았습니다.")
+                    }
+                }
             })
             .frame(width: 120, height: 28)
             .padding(.top, 28)

--- a/Oz/Source/Presentation/Login/LoginView.swift
+++ b/Oz/Source/Presentation/Login/LoginView.swift
@@ -33,13 +33,21 @@ struct LoginView: View {
             Spacer()
         }
         .frame(width: 270, height: 200)
-        .onChange(of: viewModel.shouldNavigateToChangeNameView) { shouldNavigate in
-            if shouldNavigate && viewModel.isLoginView {
+        .onChange(of: viewModel.shouldNavigateToChangeNameView ) {
+            
+            if viewModel.shouldNavigateToChangeNameView && viewModel.getFirstSignIn() {
+                print("닉네임 변경화면으로 이동")
                 router.push(view: .ChangeNameView)
             }
-        }
-        .onAppear {
-            viewModel.isLoginView = true
+            
+            if viewModel.shouldNavigateToChangeNameView && !viewModel.getFirstSignIn(){
+                print("팀 생성 참가로 이동")
+                router.push(view: .CreateOrJoinTeamView)
+            }
+            
+            if viewModel.shouldNavigateToChangeNameView && viewModel.isSignOut  {
+                print("로그아웃 이후 팀 생성 참가로 이동")
+            }
         }
     }
 }

--- a/Oz/Source/Presentation/Login/LoginViewModel.swift
+++ b/Oz/Source/Presentation/Login/LoginViewModel.swift
@@ -6,12 +6,45 @@
 //
 
 import SwiftUI
+import AuthenticationServices
+import FirebaseAuth
+import Combine
 
 class LoginViewModel: ObservableObject {
-    let accountManagingUseCase: AccountManagingUseCase
-    
+    private let accountManagingUseCase: AccountManagingUseCase
+    @Published var shouldNavigateToChangeNameView: Bool = true
+    @Published var isLoginView = true
+
     init(accountManagingUseCase: AccountManagingUseCase) {
         self.accountManagingUseCase = accountManagingUseCase
+        observeAuthStateChanges()
+    }
+    
+    public func handleSignInWithApple(request: ASAuthorizationAppleIDRequest) {
+        accountManagingUseCase.handleSignInWithApple(request: request)
+    }
+    
+    public func handleSignInWithAppleCompletion(result: Result<ASAuthorization, any Error>) {
+        accountManagingUseCase.handleSignInWithAppleCompletion(result: result)
+    }
+    
+    private func observeAuthStateChanges() {
+        Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            guard let self = self else { return }
+            if user != nil {
+                self.shouldNavigateToChangeNameView = true
+            } else {
+                self.shouldNavigateToChangeNameView = false
+            }
+        }
+    }
+    
+    public func signOut() {
+        accountManagingUseCase.signOut()
+    }
+    
+    public func deleteFirebaseAuthUser() async -> Bool {
+        return await accountManagingUseCase.deleteFirebaseAuthUser()
     }
 }
 

--- a/Oz/Source/Presentation/Login/LoginViewModel.swift
+++ b/Oz/Source/Presentation/Login/LoginViewModel.swift
@@ -14,7 +14,6 @@ class LoginViewModel: ObservableObject {
     private let accountManagingUseCase: AccountManagingUseCase
     
     @Published var shouldNavigateToChangeNameView: Bool = true
-    @Published var isSignOut = false
     
     init(accountManagingUseCase: AccountManagingUseCase) {
         self.accountManagingUseCase = accountManagingUseCase

--- a/Oz/Source/Presentation/Login/LoginViewModel.swift
+++ b/Oz/Source/Presentation/Login/LoginViewModel.swift
@@ -12,12 +12,14 @@ import Combine
 
 class LoginViewModel: ObservableObject {
     private let accountManagingUseCase: AccountManagingUseCase
+    
     @Published var shouldNavigateToChangeNameView: Bool = true
-    @Published var isLoginView = true
-
+    @Published var isSignOut = false
+    
     init(accountManagingUseCase: AccountManagingUseCase) {
         self.accountManagingUseCase = accountManagingUseCase
-        observeAuthStateChanges()
+        self.observeAuthStateChanges()
+        self.saveFirstSignIn(firstSignIn: false)
     }
     
     public func handleSignInWithApple(request: ASAuthorizationAppleIDRequest) {
@@ -45,6 +47,14 @@ class LoginViewModel: ObservableObject {
     
     public func deleteFirebaseAuthUser() async -> Bool {
         return await accountManagingUseCase.deleteFirebaseAuthUser()
+    }
+    
+    public func getFirstSignIn() -> Bool {
+        return accountManagingUseCase.getFirstSignIn()
+    }
+    
+    public func saveFirstSignIn(firstSignIn: Bool) {
+        return accountManagingUseCase.saveFirstSignIn(firstSignIn: firstSignIn)
     }
 }
 

--- a/Oz/Source/Presentation/Login/LogoutView.swift
+++ b/Oz/Source/Presentation/Login/LogoutView.swift
@@ -23,6 +23,7 @@ struct LogoutView: View {
                 HStack() {
                     Button {
                         router.pop()
+                        viewModel.isSignOut = false
                     } label: {
                         Text("취소")
                     }
@@ -30,6 +31,7 @@ struct LogoutView: View {
                     Button {
                         viewModel.signOut()
                         router.push(view: .LoginView)
+                        viewModel.isSignOut = true
                     } label: {
                         Text("로그아웃")
                             .foregroundStyle(.red)
@@ -40,9 +42,6 @@ struct LogoutView: View {
         }
         .padding(EdgeInsets(top: 50, leading: 12, bottom: 16, trailing: 12))
         .frame(width: 270, height: 200)
-        .onAppear {
-            viewModel.isLoginView = false
-        }
     }
 }
 

--- a/Oz/Source/Presentation/Login/LogoutView.swift
+++ b/Oz/Source/Presentation/Login/LogoutView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct LogoutView: View {
     @EnvironmentObject var router: Router    
-    
     @ObservedObject var viewModel: LoginViewModel
+    
     var body: some View {
         VStack(spacing: 27) {
             Text("SyncC")
@@ -28,7 +28,7 @@ struct LogoutView: View {
                     }
                     .customButtonStyle(backgroundColor: .white, foregroundColor: .darkGray2)
                     Button {
-                        viewModel.accountManagingUseCase.signOut()
+                        viewModel.signOut()
                         router.push(view: .LoginView)
                     } label: {
                         Text("로그아웃")
@@ -40,6 +40,9 @@ struct LogoutView: View {
         }
         .padding(EdgeInsets(top: 50, leading: 12, bottom: 16, trailing: 12))
         .frame(width: 270, height: 200)
+        .onAppear {
+            viewModel.isLoginView = false
+        }
     }
 }
 

--- a/Oz/Source/Presentation/Login/LogoutView.swift
+++ b/Oz/Source/Presentation/Login/LogoutView.swift
@@ -23,7 +23,6 @@ struct LogoutView: View {
                 HStack() {
                     Button {
                         router.pop()
-                        viewModel.isSignOut = false
                     } label: {
                         Text("취소")
                     }
@@ -31,7 +30,6 @@ struct LogoutView: View {
                     Button {
                         viewModel.signOut()
                         router.push(view: .LoginView)
-                        viewModel.isSignOut = true
                     } label: {
                         Text("로그아웃")
                             .foregroundStyle(.red)


### PR DESCRIPTION
## ✅ 작업한 내용
 -  login 과정에서 cancel 눌렀을 때 화면 생성/참가 화면으로 push되던 버그 수정
 - 로그인 및 로그아웃 화면 플로우 및 내부 로직 수정
 - 로그아웃 후 재접속 시 닉네임 수정 화면 분기안타고 바로 팀생성 및 참여 화면으로 전환

## ⭐️ PR Point
 <!-- 피드백 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유 -->
 - 최초 로그인 시 닉네임 변경 로직타게 처리
 - 로그아웃 후 다시 재로그인 시 닉네임 로직안타게 처리
 - 회원 탈퇴 후 다시 최초 접속 시 닉네임 로직타게 처리
 - 로그인 중간 cancel 시 다음 로직으로 넘어가는 버그 수정
 - 회원 탈퇴 충간 취소 시 로그인 화면에서 계속 있던 버그 취소 시 팀 생성 및 참가 메인 화면으로 다시 이동

## 📸 스크린샷


## 💡 관련 이슈
- Resolved: #145 
